### PR TITLE
Make Agent Cards strictly follow the Agent Card specification

### DIFF
--- a/samples/python/agents/a2a_mcp/agent_cards/air_ticketing_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/air_ticketing_agent.json
@@ -2,19 +2,11 @@
     "name": "Air Ticketing Agent",
     "description": "Helps book air tickets given a criteria",
     "url": "http://localhost:10103/",
-    "provider": null,
     "version": "1.0.0",
-    "documentationUrl": null,
     "capabilities": {
         "streaming": true,
         "pushNotifications": true,
         "stateTransitionHistory": false
-    },
-    "authentication": {
-        "credentials": null,
-        "schemes": [
-            "public"
-        ]
     },
     "defaultInputModes": [
         "text",
@@ -34,9 +26,7 @@
             ],
             "examples": [
                 "Book return tickets from SFO to LHR, starting June 24 2025 and returning 30th June 2025"
-            ],
-            "inputModes": null,
-            "outputModes": null
+            ]
         }
     ]
 }

--- a/samples/python/agents/a2a_mcp/agent_cards/air_ticketing_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/air_ticketing_agent.json
@@ -6,9 +6,9 @@
     "version": "1.0.0",
     "documentationUrl": null,
     "capabilities": {
-        "streaming": "True",
-        "pushNotifications": "True",
-        "stateTransitionHistory": "False"
+        "streaming": true,
+        "pushNotifications": true,
+        "stateTransitionHistory": false
     },
     "authentication": {
         "credentials": null,

--- a/samples/python/agents/a2a_mcp/agent_cards/car_rental_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/car_rental_agent.json
@@ -6,9 +6,9 @@
     "version": "1.0.0",
     "documentationUrl": null,
     "capabilities": {
-        "streaming": "True",
-        "pushNotifications": "True",
-        "stateTransitionHistory": "False"
+        "streaming": true,
+        "pushNotifications": true,
+        "stateTransitionHistory": false
     },
     "authentication": {
         "credentials": null,

--- a/samples/python/agents/a2a_mcp/agent_cards/car_rental_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/car_rental_agent.json
@@ -2,19 +2,11 @@
     "name": "Car Rental Agent",
     "description": "Helps book car rental",
     "url": "http://localhost:10105/",
-    "provider": null,
     "version": "1.0.0",
-    "documentationUrl": null,
     "capabilities": {
         "streaming": true,
         "pushNotifications": true,
         "stateTransitionHistory": false
-    },
-    "authentication": {
-        "credentials": null,
-        "schemes": [
-            "public"
-        ]
     },
     "defaultInputModes": [
         "text",
@@ -34,9 +26,7 @@
             ],
             "examples": [
                 "Book a rental car in London, starting on June 20, 2025, and ending on July 10, 2025"
-            ],
-            "inputModes": null,
-            "outputModes": null
+            ]
         }
     ]
 }

--- a/samples/python/agents/a2a_mcp/agent_cards/hotel_booking_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/hotel_booking_agent.json
@@ -6,9 +6,9 @@
     "version": "1.0.0",
     "documentationUrl": null,
     "capabilities": {
-        "streaming": "True",
-        "pushNotifications": "True",
-        "stateTransitionHistory": "False"
+        "streaming": true,
+        "pushNotifications": true,
+        "stateTransitionHistory": false
     },
     "authentication": {
         "credentials": null,

--- a/samples/python/agents/a2a_mcp/agent_cards/hotel_booking_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/hotel_booking_agent.json
@@ -2,19 +2,11 @@
     "name": "Hotel Booking Agent",
     "description": "Helps book hotels given a criteria",
     "url": "http://localhost:10104/",
-    "provider": null,
     "version": "1.0.0",
-    "documentationUrl": null,
     "capabilities": {
         "streaming": true,
         "pushNotifications": true,
         "stateTransitionHistory": false
-    },
-    "authentication": {
-        "credentials": null,
-        "schemes": [
-            "public"
-        ]
     },
     "defaultInputModes": [
         "text",
@@ -34,9 +26,7 @@
             ],
             "examples": [
                 "Book a hotel for 1 adult in Central London, starting June 24 2025 for 2 nights"
-            ],
-            "inputModes": null,
-            "outputModes": null
+            ]
         }
     ]
 }

--- a/samples/python/agents/a2a_mcp/agent_cards/orchestrator_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/orchestrator_agent.json
@@ -6,9 +6,9 @@
     "version": "1.0.0",
     "documentationUrl": null,
     "capabilities": {
-        "streaming": "True",
-        "pushNotifications": "True",
-        "stateTransitionHistory": "False"
+        "streaming": true,
+        "pushNotifications": true,
+        "stateTransitionHistory": false
     },
     "authentication": {
         "credentials": null,

--- a/samples/python/agents/a2a_mcp/agent_cards/orchestrator_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/orchestrator_agent.json
@@ -2,19 +2,11 @@
     "name": "Orchestrator Agent",
     "description": "Orchestrates the task generation and execution",
     "url": "http://localhost:10101/",
-    "provider": null,
     "version": "1.0.0",
-    "documentationUrl": null,
     "capabilities": {
         "streaming": true,
         "pushNotifications": true,
         "stateTransitionHistory": false
-    },
-    "authentication": {
-        "credentials": null,
-        "schemes": [
-            "public"
-        ]
     },
     "defaultInputModes": [
         "text",
@@ -34,9 +26,7 @@
             ],
             "examples": [
                 "Plan my trip to London, submit an expense report"
-            ],
-            "inputModes": null,
-            "outputModes": null
+            ]
         }
     ]
 }

--- a/samples/python/agents/a2a_mcp/agent_cards/planner_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/planner_agent.json
@@ -2,15 +2,7 @@
     "name": "Langraph Planner Agent",
     "description": "Helps breakdown a request in to actionable tasks",
     "url": "http://localhost:10102/",
-    "provider": null,
     "version": "1.0.0",
-    "documentationUrl": null,
-    "authentication": {
-        "credentials": null,
-        "schemes": [
-            "public"
-        ]
-    },
     "capabilities": {
         "streaming": true,
         "pushNotifications": true,
@@ -34,9 +26,7 @@
             ],
             "examples": [
                 "Plan my business trip from San Francisco to London, submit an expense report"
-            ],
-            "inputModes": null,
-            "outputModes": null
+            ]
         }
     ]
 }

--- a/samples/python/agents/a2a_mcp/agent_cards/planner_agent.json
+++ b/samples/python/agents/a2a_mcp/agent_cards/planner_agent.json
@@ -12,9 +12,9 @@
         ]
     },
     "capabilities": {
-        "streaming": "True",
-        "pushNotifications": "True",
-        "stateTransitionHistory": "False"
+        "streaming": true,
+        "pushNotifications": true,
+        "stateTransitionHistory": false
     },
     "defaultInputModes": [
         "text",


### PR DESCRIPTION
# Make Agent Cards strictly follow Agent Card specification
The specification for Agent Cards specifies that the `provider`, `documentationUrl`, `inputModes` and `outputModes` are optional not nullable (present but null). I have removed these fields as a whole to match this expectation from the specification
[The official TS specification](https://github.com/google-a2a/A2A/blob/main/types/src/types.ts) also has no mention of the `authentication` field, so I have deleted it.