### PR TITLE
fix: host agent to correctly initialize with async card resolution

### DIFF
--- a/samples/python/hosts/multiagent/host_agent.py
+++ b/samples/python/hosts/multiagent/host_agent.py
@@ -45,10 +45,14 @@ class HostAgent:
         self.httpx_client = http_client
         self.remote_agent_connections: dict[str, RemoteAgentConnections] = {}
         self.cards: dict[str, AgentCard] = {}
-        task_group = asyncio.TaskGroup()
         self.agents: str = ''
-        for address in remote_agent_addresses:
-            task_group.create_task(self.retrieve_card(address))
+        loop = asyncio.get_running_loop()
+        loop.create_task(self.init_remote_agent_addresses(remote_agent_addresses))
+
+    async def init_remote_agent_addresses(self, remote_agent_addresses: list[str]):
+        async with asyncio.TaskGroup() as task_group:
+            for address in remote_agent_addresses:
+                task_group.create_task(self.retrieve_card(address))
         # The task groups run in the background and complete.
         # Once completed the self.agents string is set and the remote
         # connections are established.


### PR DESCRIPTION
# Current issue

If you initialize HostAgent with some hosts instead of an empty array:

<img width="742" alt="Screenshot 2025-06-13 at 11 49 22 AM" src="https://github.com/user-attachments/assets/a3f6df13-0040-4221-907c-4d1b6f496a0b" />

It will fail with the following error:
```
  File "a2a-samples/demo/ui/service/server/adk_host_manager.py", line 70, in __init__
    self._host_agent = HostAgent(['http://localhost:9999'], http_client, self.task_callback)
                       ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "a2a-samples/samples/python/hosts/multiagent/host_agent.py", line 51, in __init__
    task_group.create_task(self.retrieve_card(address))
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[...]/lib/python3.13/asyncio/taskgroups.py", line 188, in create_task
    raise RuntimeError(f"TaskGroup {self!r} has not been entered")
RuntimeError: TaskGroup <TaskGroup> has not been entered

ERROR:    Application startup failed. Exiting.
```
