### PR TITLE
feat(cli): Add support for bearer token authentication

### DIFF
--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -32,7 +32,7 @@ from common.utils.push_notification_auth import PushNotificationReceiverAuth
 
 @click.command()
 @click.option('--agent', default='http://localhost:10000')
-@click.option('--bearer-token')
+@click.option('--bearer-token', help='Bearer token for authentication.', envvar='A2A_CLI_BEARER_TOKEN')
 @click.option('--session', default=0)
 @click.option('--history', default=False)
 @click.option('--use_push_notifications', default=False)

--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -32,6 +32,7 @@ from common.utils.push_notification_auth import PushNotificationReceiverAuth
 
 @click.command()
 @click.option('--agent', default='http://localhost:10000')
+@click.option('--bearer-token')
 @click.option('--session', default=0)
 @click.option('--history', default=False)
 @click.option('--use_push_notifications', default=False)
@@ -39,6 +40,7 @@ from common.utils.push_notification_auth import PushNotificationReceiverAuth
 @click.option('--header', multiple=True)
 async def cli(
     agent,
+    bearer_token,
     session,
     history,
     use_push_notifications: bool,
@@ -46,6 +48,8 @@ async def cli(
     header,
 ):
     headers = {h.split('=')[0]: h.split('=')[1] for h in header}
+    if bearer_token:
+        headers['Authorization'] = f'Bearer {bearer_token}'
     print(f'Will use headers: {headers}')
     async with httpx.AsyncClient(timeout=30, headers=headers) as httpx_client:
         card_resolver = A2ACardResolver(httpx_client, agent)


### PR DESCRIPTION
# Description

The CLI host application previously lacked the ability to connect to A2A agents that require authentication, such as those deployed on secure platforms like Google Cloud Run. 

This made it impossible to use the CLI for testing or interacting with protected agent endpoints.

This commit introduces a `--bearer-token` command-line option. When this option is used, the provided token is included in the `Authorization` header of all outgoing HTTP requests to the agent. 

This allows the CLI to successfully authenticate and collaborate with agents that require bearer token authorization.

Example usage: uv run python __main__.py --agent YOUR-CLOUDRUN-APP-URL --bearer-token "$(gcloud auth print-identity-token)"

