### PR TITLE
fix(demo): Resolve ModuleNotFoundError in UI

### DIFF
--- a/demo/ui/main.py
+++ b/demo/ui/main.py
@@ -4,6 +4,10 @@ run:
 """
 
 import os
+import sys
+
+# Add the project root to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'samples', 'python')))
 
 from contextlib import asynccontextmanager
 


### PR DESCRIPTION
The UI application was failing with a `ModuleNotFoundError` because the `hosts` module, located in the `samples/python` directory, was not in the Python path.

This commit fixes the issue by adding the `samples/python` directory to the `sys.path` at runtime in `demo/ui/main.py`. This ensures that the Python interpreter can find the `hosts` module and the application can start without errors.

Fixes #188
Related to #11
