### PR TITLE
fix: Resolve compile errors in `weather_agent` by updating A2A Java S…

### DIFF
--- a/samples/multi_language/python_and_java_multiagent/README.md
+++ b/samples/multi_language/python_and_java_multiagent/README.md
@@ -40,7 +40,7 @@ The `AgentCard` and `AgentExecutor` classes mentioned above are part of the [A2A
 ```xml
 ...
 <properties>
-    <io.a2a.sdk.version>0.2.3</io.a2a.sdk.version>
+    <io.a2a.sdk.version>0.2.3.Beta</io.a2a.sdk.version>
     ...
 </properties>    
 ...
@@ -138,8 +138,8 @@ uv run .
 
 > *⚠️ This is a temporary step until our A2A Java SDK is released.
 > The A2A Java SDK isn't available yet in Maven Central but will be soon. For now, be
-> sure to check out the latest tag (you can see the tags [here](https://github.com/a2aproject/a2a-java/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3`, you can use
-`git checkout 0.2.3` as shown below.*
+> sure to check out the latest tag (you can see the tags [here](https://github.com/a2aproject/a2a-java/tags)), build from the tag, and reference that version below. For example, if the latest tag is `0.2.3.Beta`, you can use
+`git checkout 0.2.3.Beta` as shown below.*
 
 Open a new terminal and build the A2A Java SDK:
 
@@ -147,7 +147,7 @@ Open a new terminal and build the A2A Java SDK:
 git clone https://github.com/a2aproject/a2a-java
 cd a2a-java
 git fetch --tags
-git checkout 0.2.3
+git checkout 0.2.3.Beta
 mvn clean install
 ```
 

--- a/samples/multi_language/python_and_java_multiagent/weather_agent/pom.xml
+++ b/samples/multi_language/python_and_java_multiagent/weather_agent/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <io.a2a.sdk.version>0.2.3</io.a2a.sdk.version>
+        <io.a2a.sdk.version>0.2.3.Beta</io.a2a.sdk.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
         <quarkus.platform.version>3.22.3</quarkus.platform.version>
         <quarkus.langchain4j.version>1.0.0</quarkus.langchain4j.version>


### PR DESCRIPTION
**fix: Resolve compile errors in `weather_agent` by updating A2A Java SDK version**

This Pull Request addresses a compilation issue encountered when following the build instructions for the A2A Java SDK within the `multi_language/python_and_java_multiagent` sample, specifically for the `weather_agent`.

**Problem:**
The current build instructions at https://github.com/a2aproject/a2a-samples/tree/main/samples/multi_language/python_and_java_multiagent#2-build-our-a2a-java-sdk specify checking out tag `0.2.3` of the `a2a-java` repository. However, upon inspection of https://github.com/a2aproject/a2a-java/tags, it's evident that the tag `0.2.3` does not exist. This leads to compilation failures when attempting to build the `weather_agent`.

**Solution:**
By updating the `a2a-java` version reference to `0.2.3.Beta`, the compile errors in `weather_agent` are resolved. The tag `0.2.3.Beta` is correctly available at https://github.com/a2aproject/a2a-java/releases/tag/0.2.3.Beta.

**Proposed Change:**
This PR updates the relevant configuration or build script in `a2a-samples` to use version `0.2.3.Beta` for the A2A Java SDK dependency.

It is also recommended that the documentation at https://github.com/a2aproject/a2a-samples/tree/main/samples/multi_language/python_and_java_multiagent#2-build-our-a2a-java-sdk be updated to reflect the correct command:

```bash
git clone https://github.com/a2aproject/a2a-java
cd a2a-java
git fetch --tags
git checkout 0.2.3.Beta  # Changed from 0.2.3
mvn clean install
