### PR TITLE
fix: Update tasks/send to message/send to align with A2A v0.2.5 specification

### DIFF
--- a/samples/java/README.md
+++ b/samples/java/README.md
@@ -79,7 +79,7 @@ The project implements an intelligent translation agent supporting multi-languag
 Complete implementation of A2A protocol specifications:
 
 **Core Operations**:
-- `tasks/send`: Send task messages
+- `message/send`: Send task messages
 - `tasks/get`: Query task status
 - `tasks/cancel`: Cancel task execution
 
@@ -172,7 +172,7 @@ curl -X POST http://localhost:8080/a2a \
   -d '{
     "jsonrpc": "2.0",
     "id": "request-1",
-    "method": "tasks/send",
+    "method": "message/send",
     "params": {
       "id": "translation-task-1",
       "message": {
@@ -199,7 +199,7 @@ curl -X POST http://localhost:8080/a2a/stream \
   -d '{
     "jsonrpc": "2.0",
     "id": "stream-request-1",
-    "method": "tasks/send",
+    "method": "message/send",
     "params": {
       "id": "streaming-translation-task",
       "message": {

--- a/samples/java/client/src/main/java/com/google/a2a/client/A2AClient.java
+++ b/samples/java/client/src/main/java/com/google/a2a/client/A2AClient.java
@@ -60,7 +60,7 @@ public class A2AClient {
         JSONRPCRequest request = new JSONRPCRequest(
             generateRequestId(),
             "2.0",
-            "tasks/send",
+            "message/send",
             params
         );
         
@@ -116,7 +116,7 @@ public class A2AClient {
                 JSONRPCRequest request = new JSONRPCRequest(
                     generateRequestId(),
                     "2.0",
-                    "tasks/send",
+                    "message/send",
                     params
                 );
                 

--- a/samples/java/server/README.md
+++ b/samples/java/server/README.md
@@ -54,7 +54,7 @@ Content-Type: application/json
 {
   "jsonrpc": "2.0",
   "id": "request-1",
-  "method": "tasks/send",
+  "method": "message/send",
   "params": {
     "id": "task-1",
     "message": {

--- a/samples/java/server/src/main/java/com/google/a2a/server/A2AController.java
+++ b/samples/java/server/src/main/java/com/google/a2a/server/A2AController.java
@@ -65,7 +65,7 @@ public class A2AController {
         }
 
         JSONRPCResponse response = switch (request.method()) {
-            case "tasks/send" -> server.handleTaskSend(request);
+            case "message/send" -> server.handleTaskSend(request);
             case "tasks/get" -> server.handleTaskGet(request);
             case "tasks/cancel" -> server.handleTaskCancel(request);
             default -> {
@@ -101,7 +101,7 @@ public class A2AController {
         // Process task asynchronously
         CompletableFuture.runAsync(() -> {
             try {
-                if (!"tasks/send".equals(request.method())) {
+                if (!"message/send".equals(request.method())) {
                     sendErrorEvent(emitter, request.id(), ErrorCode.METHOD_NOT_FOUND, "Method not found");
                     return;
                 }

--- a/samples/java/server/src/test/java/com/google/a2a/server/A2AServerTest.java
+++ b/samples/java/server/src/test/java/com/google/a2a/server/A2AServerTest.java
@@ -104,7 +104,7 @@ class A2AServerTest {
         JSONRPCRequest request = new JSONRPCRequest(
             "request-1",
             "2.0",
-            "tasks/send",
+            "message/send",
             params
         );
         
@@ -156,7 +156,7 @@ class A2AServerTest {
         JSONRPCRequest sendRequest = new JSONRPCRequest(
             "request-1",
             "2.0",
-            "tasks/send",
+            "message/send",
             sendParams
         );
         
@@ -216,7 +216,7 @@ class A2AServerTest {
         JSONRPCRequest sendRequest = new JSONRPCRequest(
             "request-1",
             "2.0",
-            "tasks/send",
+            "message/send",
             sendParams
         );
         


### PR DESCRIPTION
# Description
Update `tasks/send` to `message/send` to align with [A2A v0.2.5 specification](https://a2aproject.github.io/A2A/v0.2.5/specification/)

- Updated all occurrences of "tasks/send" to "message/send" in Java codebase
- Modified A2AServerTest.java: 3 occurrences in test methods
- Modified A2AController.java: 2 occurrences in request routing
- Modified A2AClient.java: 2 occurrences in client methods
- Updated documentation in README.md files with corrected API examples

