### PR TITLE
fix: README.md

### DIFF
--- a/samples/python/agents/adk_expense_reimbursement/README.md
+++ b/samples/python/agents/adk_expense_reimbursement/README.md
@@ -15,7 +15,7 @@ This agent takes text requests from the client and, if any details are missing, 
 
 1. Navigate to the samples directory:
     ```bash
-    cd samples/python/agents/google_adk
+    cd samples/python/agents/adk_expense_reimbursement
     ```
 2. Create an environment file with your API key:
 


### PR DESCRIPTION
# Description

Update the README bash command to `cd` into the renamed `adk_expense_reimbursement` directory
