### PR TITLE
fix(client): Resolve "Task not found" error and improve stability

### DIFF
--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -203,7 +203,7 @@ async def completeTask(
                 )
             )
             if isinstance(taskResultResponse.root, JSONRPCErrorResponse):
-                print(f'Error: {taskResultResponse.root.error}')
+                print(f'Error: {taskResultResponse.root.error}, contextId: {contextId}, taskId: {taskId}')
                 return False, contextId, taskId
             taskResult = taskResultResponse.root.result
     else:


### PR DESCRIPTION
This commit addresses several race conditions and error handling issues in the `client.py` script that led to crashes and the `Task not found` error.

- Prevents the client from fetching a task with `get_task` if it has already been marked as 'completed' in the event stream. This resolves the primary cause of the `Task not found` error.
- Adds a check for `JSONRPCErrorResponse` to gracefully handle server-side errors without crashing the client.
- Corrects the return value structure for recursive calls when a task's state is `input_required`.
- Enhances error logs by including the `contextId` and `taskId` to provide better context for debugging.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
