### PR TITLE
docs: Improve Cloud Run agent deployment and testing instructions

### DIFF
--- a/samples/python/agents/adk_cloud_run/README.md
+++ b/samples/python/agents/adk_cloud_run/README.md
@@ -158,6 +158,8 @@ uv run . --agent {your-cloud-run-service-url} --bearer-token "$(gcloud auth prin
 
 Important: The sample code provided is for demonstration purposes and illustrates the mechanics of the Agent-to-Agent (A2A) protocol. When building production applications, it is critical to treat any agent operating outside of your direct control as a potentially untrusted entity.
 
-All data received from an external agent—including but not limited to its AgentCard, messages, artifacts, and task statuses—should be handled as untrusted input. For example, a malicious agent could provide an AgentCard containing crafted data in its fields (e.g., description, name, skills.description). If this data is used without sanitization to construct prompts for a Large Language Model (LLM), it could expose your application to prompt injection attacks. Failure to properly validate and sanitize this data before use can introduce security vulnerabilities into your application.
+All data received from an external agent—including but not limited to its AgentCard, messages, artifacts, and task statuses—should be handled as untrusted input.
+
+For example, a malicious agent could provide an AgentCard containing crafted data in its fields (e.g., description, name, skills.description). If this data is used without sanitization to construct prompts for a Large Language Model (LLM), it could expose your application to prompt injection attacks. Failure to properly validate and sanitize this data before use can introduce security vulnerabilities into your application.
 
 Developers are responsible for implementing appropriate security measures, such as input validation and secure handling of credentials to protect their systems and users.


### PR DESCRIPTION
This commit provides several improvements to the documentation for deploying and testing the A2A Cloud Run agent.

Key updates include:
- Corrected the `gcloud projects add-iam-policy-binding` command by adding missing backslashes for multi-line execution and explicitly including the `roles/secretmanager.secretAccessor` role.
- Added a `--memory "1Gi"` limit to the `gcloud run deploy` command for better resource management and removed the `APP_URL` environment variable from the initial deployment, as it's not needed at this stage.
- Introduced a new section detailing how to update the Cloud Run service with the `APP_URL` environment variable once the service URL is known.
- Added a comprehensive section for testing the deployed agent using the A2A CLI, including the necessary authentication command.

These changes enhance the clarity and accuracy of the deployment guide, making it easier for users to set up and verify the Cloud Run agent.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
