### PR TITLE
fix: expense reimbursement sample agent env var reference and function parsing errors

### DIFF
--- a/samples/python/agents/adk_expense_reimbursement/README.md
+++ b/samples/python/agents/adk_expense_reimbursement/README.md
@@ -21,7 +21,7 @@ This agent takes text requests from the client and, if any details are missing, 
 2. Create an environment file with your API key:
 
    ```bash
-   echo "GOOGLE_API_KEY=your_api_key_here" > .env
+   echo "GEMINI_API_KEY=your_api_key_here" > .env
    ```
 
 3. Run an agent:

--- a/samples/python/agents/adk_expense_reimbursement/__main__.py
+++ b/samples/python/agents/adk_expense_reimbursement/__main__.py
@@ -33,9 +33,9 @@ def main(host, port):
     try:
         # Check for API key only if Vertex AI is not configured
         if not os.getenv('GOOGLE_GENAI_USE_VERTEXAI') == 'TRUE':
-            if not os.getenv('GOOGLE_API_KEY'):
+            if not os.getenv('GEMINI_API_KEY'):
                 raise MissingAPIKeyError(
-                    'GOOGLE_API_KEY environment variable not set and GOOGLE_GENAI_USE_VERTEXAI is not TRUE.'
+                    'GEMINI_API_KEY environment variable not set and GOOGLE_GENAI_USE_VERTEXAI is not TRUE.'
                 )
 
         capabilities = AgentCapabilities(streaming=True)

--- a/samples/python/agents/adk_expense_reimbursement/agent.py
+++ b/samples/python/agents/adk_expense_reimbursement/agent.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+from typing import Optional
 
 from collections.abc import AsyncIterable
 from typing import Any
@@ -20,9 +21,9 @@ request_ids = set()
 
 
 def create_request_form(
-    date: str | None = None,
-    amount: str | None = None,
-    purpose: str | None = None,
+    date: Optional[str] = None,
+    amount: Optional[str] = None,
+    purpose: Optional[str] = None,
 ) -> dict[str, Any]:
     """Create a request form for the employee to fill out.
 
@@ -49,7 +50,7 @@ def create_request_form(
 def return_form(
     form_request: dict[str, Any],
     tool_context: ToolContext,
-    instructions: str | None = None,
+    instructions: Optional[str] = None,
 ) -> dict[str, Any]:
     """Returns a structured json object indicating a form to complete.
 

--- a/samples/python/agents/adk_expense_reimbursement/pyproject.toml
+++ b/samples/python/agents/adk_expense_reimbursement/pyproject.toml
@@ -3,12 +3,12 @@ name = "a2a-sample-agent-adk"
 version = "0.1.0"
 description = "Sample Google ADK-based Expense Reimbursement agent hosted as an A2A server." 
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 dependencies = [
     "a2a-sdk>=0.2.16",
     "click>=8.1.8",
-    "google-adk>=1.0.0",
-    "google-genai>=1.9.0",
+    "google-adk>=1.8.0",
+    "google-genai>=1.27.0",
     "python-dotenv>=1.1.0",
     "litellm",
 ]


### PR DESCRIPTION
# Description

Fixes a few issues in the expense reimbursement agent sample code, including dynamic function parameter parsing (described in more detail here: google/adk-python#1634), and the env var referenced in the README 

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #212  🦕
