### PR TITLE
fix: address a2a 0.3.0 changes

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -42,3 +42,4 @@ jobs:
           VALIDATE_JUPYTER_NBQA_FLAKE8: false
           VALIDATE_JUPYTER_NBQA_MYPY: false
           VALIDATE_JUPYTER_NBQA_PYLINT: false
+          VALIDATE_JUPYTER_NBQA_RUFF: false

--- a/notebooks/a2a_quickstart.ipynb
+++ b/notebooks/a2a_quickstart.ipynb
@@ -179,7 +179,7 @@
         "# This cell shall be removed when google-adk releases the version next to >1.9.0\n",
         "# (after https://github.com/google/adk-python/pull/2297)\n",
         "\n",
-        "# noqa: E402\n",
+        "\n",
         "import sys\n",
         "\n",
         "from a2a.client import client as real_client_module\n",


### PR DESCRIPTION
# Description

This PR modifies the quickstart notebook to address the changes in a2a-sdk version 0.3.0: https://github.com/a2aproject/a2a-python/releases/tag/v0.3.0  

The notebook also upgrades google-adk to 1.9.0 and pins both versions   

Previously, incompatibilities between google-adk and a2a-sdk caused failed imports and wrong parsing of client response.   

This change mainly modifies the A2ASimpleClient to use new recommended approach from a2a 0.3.0, simplifies the parsing of the client response and apply a workaround for the A2ACardResolver that shall be removed after google-sdk next release.   

Fixes #291
