### PR TITLE
Fix: Prevent DefaultRequestHandler rejection by tracking per-agent task state

### DIFF
--- a/samples/python/agents/airbnb_planner_multiagent/host_agent/routing_agent.py
+++ b/samples/python/agents/airbnb_planner_multiagent/host_agent/routing_agent.py
@@ -1,6 +1,3 @@
-
-
-
 # ruff: noqa: E501
 # pylint: disable=logging-fstring-interpolation
 import asyncio
@@ -237,7 +234,7 @@ class RoutingAgent:
         # Initialize the main task dictionary if it doesn't exist
         if 'agent_tasks' not in state:
             state['agent_tasks'] = {}
-        
+
         # Get the specific task info for this agent, or an empty dict
         agent_task_info = state['agent_tasks'].get(agent_name, {})
 
@@ -298,14 +295,14 @@ class RoutingAgent:
             return None
 
         task_result = send_response.root.result
-        
+
         # Save the task and context IDs for this specific agent
         state['agent_tasks'][agent_name] = {
             'task_id': task_result.id,
             'context_id': task_result.context_id,
             'status': task_result.status.state,
         }
-        
+
         return task_result
 
 


### PR DESCRIPTION
# Description
This PR resolves [#304](https://github.com/a2aproject/a2a-samples/issues/304) and also addresses a related issue discovered during the investigation and fix. The root cause has been identified in the comment of #304

✅ Summary of Fixes
🟢 Scenario 1 — Fix for issue #304
Problem: The host agent generates a new task_id, either regardless of the situation or when it fails to retrieve the task_id.
Fix: The host agent now:
Checks for an existing task for the target agent.
Reuses the task_id only if the task_id is successfully retrieved and task is not in a terminal state (TaskState.completed).
Otherwise, it sets task_id to None.
This allows the DefaultRequestHandler to generate the task_id and avoid TaskNotFound error.

🟠 Scenario 2 — New issue discovered and addressed in this PR
Problem: While addressing Scenario 1, it became clear that using a universal task_id across multiple remote agents introduces conflicts:
For example, remote_agent_1 generates a task_id, which is then reused by remote_agent_2.
Since remote_agent_2 has never seen that task ID before, the DefaultRequestHandler rejects it when there is a task_id an there is no task, throwing the same TaskNotFound error as in scenario 1
Fix: Introduced a per-agent tracking dictionary (state['agent_tasks']) that stores:
task_id, context_id, and status independently for each agent.
Ensures that each remote agent uses its own correct task state and ID, avoiding cross-agent contamination.

🧪 Scope
This PR applies the fix only in the demonstrated agent as a proof of concept.

Similar logic should be extended to other samples for consistent multi-agent compatibility.
Other samples with the same issue:
- a2a-mcp-without-framework
- azureaifoundry_sdk
- headless_agent_auth

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #304 🦕
