### PR TITLE
Add http-server extra to a2a-sdk in requirements

### DIFF
--- a/samples/python/requirements.txt
+++ b/samples/python/requirements.txt
@@ -1,4 +1,3 @@
-a2a-sdk
+a2a-sdk[http-server]>=0.3.0
 uvicorn
 python-dotenv
-a2a-sdk[http-server]


### PR DESCRIPTION
Without adding a2a-sdk[http-server] in requirements.txt, tutorial posted on homepage https://a2a-protocol.org/ will not work.

https://a2a-protocol.org/latest/tutorials/python/2-setup/

https://github.com/a2aproject/A2A/blob/main/docs/tutorials/python/2-setup.md
