### PR TITLE
Fix typo of task.contextId

### DIFF
--- a/samples/python/agents/content_planner/agent_executor.py
+++ b/samples/python/agents/content_planner/agent_executor.py
@@ -58,7 +58,7 @@ class ADKAgentExecutor(AgentExecutor):
         task = context.current_task or new_task(context.message)
         await event_queue.enqueue_event(task)
 
-        updater = TaskUpdater(event_queue, task.id, task.contextId)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
         if context.call_context:
             user_id = context.call_context.user.user_name
         else:
@@ -68,7 +68,7 @@ class ADKAgentExecutor(AgentExecutor):
             # Update status with custom message
             await updater.update_status(
                 TaskState.working,
-                new_agent_text_message(self.status_message, task.contextId, task.id),
+                new_agent_text_message(self.status_message, task.context_id, task.id),
             )
 
             # Process with ADK agent
@@ -76,7 +76,7 @@ class ADKAgentExecutor(AgentExecutor):
                 app_name=self.agent.name,
                 user_id=user_id,
                 state={},
-                session_id=task.contextId,
+                session_id=task.context_id,
             )
 
             content = types.Content(
@@ -106,6 +106,6 @@ class ADKAgentExecutor(AgentExecutor):
         except Exception as e:
             await updater.update_status(
                 TaskState.failed,
-                new_agent_text_message(f"Error: {e!s}", task.contextId, task.id),
+                new_agent_text_message(f"Error: {e!s}", task.context_id, task.id),
                 final=True,
             )


### PR DESCRIPTION
# Description
Fixing typo in the *Content Planner Agent*(samples/python/agents/content_planner).

The current implementation mistakenly uses `task.contextId` instead of the correct `task.context_id`. 
While the agent can start running, this typo eventually causes an error when the host agent attempts to use it.

This PR corrects the typo to ensure proper execution.

