### PR TITLE
fix: Path to agent card should be ./well-known/agent-card.json

### DIFF
--- a/samples/java/custom_java_impl/README.md
+++ b/samples/java/custom_java_impl/README.md
@@ -36,7 +36,7 @@ Spring Boot-based A2A server SDK, integrated with Spring AI framework:
 
 - **Key Features**:
   - Complete JSON-RPC 2.0 support
-  - Agent card publishing (`/.well-known/agent.json`)
+  - Agent card publishing (`/.well-known/agent-card.json`)
   - Task management (send, query, cancel)
   - Streaming response support (Server-Sent Events)
   - Spring AI integration supporting OpenAI and other models
@@ -94,7 +94,7 @@ Complete implementation of A2A protocol specifications:
 
 **Synchronous Communication**: 
 - HTTP POST `/a2a` - Standard JSON-RPC requests
-- HTTP GET `/.well-known/agent.json` - Agent information retrieval
+- HTTP GET `/.well-known/agent-card.json` - Agent information retrieval
 
 **Streaming Communication**:
 - HTTP POST `/a2a/stream` - Server-Sent Events
@@ -142,7 +142,7 @@ cd server
 ```
 
 The server will start at `http://localhost:8080`, providing the following endpoints:
-- `http://localhost:8080/.well-known/agent.json` - Agent information
+- `http://localhost:8080/.well-known/agent-card.json` - Agent information
 - `http://localhost:8080/a2a` - A2A protocol endpoint
 - `http://localhost:8080/a2a/stream` - Streaming endpoint
 
@@ -160,7 +160,7 @@ cd client
 ### Get Agent Information
 
 ```bash
-curl -X GET http://localhost:8080/.well-known/agent.json \
+curl -X GET http://localhost:8080/.well-known/agent-card.json \
   -H "Accept: application/json"
 ```
 

--- a/samples/java/custom_java_impl/client/src/main/java/com/google/a2a/client/A2AClient.java
+++ b/samples/java/custom_java_impl/client/src/main/java/com/google/a2a/client/A2AClient.java
@@ -181,7 +181,7 @@ public class A2AClient {
     public AgentCard getAgentCard() throws A2AClientException {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(baseUrl + "/.well-known/agent.json"))
+                .uri(URI.create(baseUrl + "/.well-known/agent-card.json"))
                 .header("Accept", "application/json")
                 .GET()
                 .build();

--- a/samples/java/custom_java_impl/server/README.md
+++ b/samples/java/custom_java_impl/server/README.md
@@ -10,7 +10,7 @@ The A2A Server SDK is a comprehensive Java library that implements the A2A proto
 
 ### 🚀 **Complete A2A Protocol Implementation**
 - **JSON-RPC 2.0** support for all A2A operations
-- **Agent Card** publishing at `/.well-known/agent.json`
+- **Agent Card** publishing at `/.well-known/agent-card.json`
 - **Task Management** - send, query, cancel operations
 - **Streaming Support** - real-time task updates via Server-Sent Events
 - **Error Handling** - comprehensive error management with proper codes
@@ -40,7 +40,7 @@ The A2A Server SDK is a comprehensive Java library that implements the A2A proto
 
 ### Agent Card Endpoint
 ```http
-GET /.well-known/agent.json
+GET /.well-known/agent-card.json
 Accept: application/json
 ```
 

--- a/samples/java/custom_java_impl/server/src/main/java/com/google/a2a/server/A2AController.java
+++ b/samples/java/custom_java_impl/server/src/main/java/com/google/a2a/server/A2AController.java
@@ -175,7 +175,7 @@ public class A2AController {
     /**
      * Get agent card information
      */
-    @GetMapping("/.well-known/agent.json")
+    @GetMapping("/.well-known/agent-card.json")
     public ResponseEntity<AgentCard> getAgentCard() {
         return ResponseEntity.ok(server.getAgentCard());
     }


### PR DESCRIPTION
Specification for a2a specifies recommended location for agent card to  be https://{server_domain}/.well-known/agent-card.json , see https://a2a-protocol.org/v0.3.0/specification/#53-recommended-location .

Currently the java weather_mcp example is failing as it expects the path to be /.well-known/agent-card.json