### PR TITLE
java: use message/stream + SSE parsing; keep message/send

### DIFF
--- a/samples/java/custom_java_impl/server/src/main/java/com/google/a2a/server/A2AController.java
+++ b/samples/java/custom_java_impl/server/src/main/java/com/google/a2a/server/A2AController.java
@@ -101,7 +101,7 @@ public class A2AController {
         // Process task asynchronously
         CompletableFuture.runAsync(() -> {
             try {
-                if (!"message/send".equals(request.method())) {
+                if (!"message/stream".equals(request.method())) {
                     sendErrorEvent(emitter, request.id(), ErrorCode.METHOD_NOT_FOUND, "Method not found");
                     return;
                 }


### PR DESCRIPTION
- Client now POSTs JSON-RPC `{ "method": "message/stream" }` to `/a2a/stream`.
- SSE parsing reads only `data:` lines and parses on blank-line boundaries.
- Server `/a2a/stream` requires `message/stream`.
- Non-streaming remains on `/a2a` with `message/send`.

Protocol alignment (current)
- This change updates the Java sample to the **current A2A protocol version (v0.3.0)**:
  - Streaming RPC: `message/stream`
  - Non-streaming RPC: `message/send`

Fixes #358 🦕
