### PR TITLE
fix: Remove unnecessary dependency for the weather_mcp Java agent

### DIFF
--- a/samples/java/agents/weather_mcp/pom.xml
+++ b/samples/java/agents/weather_mcp/pom.xml
@@ -59,18 +59,6 @@
             <artifactId>quarkus-langchain4j-mcp</artifactId>
             <version>${quarkus.langchain4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.quarkiverse.langchain4j</groupId>
-            <artifactId>quarkus-langchain4j-mcp-deployment</artifactId>
-            <version>${quarkus.langchain4j.version}</version>
-            <type>pom</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
# Description

This PRs removes a dependency that isn't actually needed for the `weather_mcp` Java agent:

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

