### PR TITLE
fix: Explicitly set the Gemini chat model id for the Java agents

### DIFF
--- a/samples/java/agents/content_editor/src/main/resources/application.properties
+++ b/samples/java/agents/content_editor/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.http.port=10003
 quarkus.langchain4j.ai.gemini.timeout=40000
+quarkus.langchain4j.ai.gemini.chat-model.model-id=gemini-2.5-flash

--- a/samples/java/agents/content_writer/src/main/resources/application.properties
+++ b/samples/java/agents/content_writer/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 quarkus.http.port=10002
 quarkus.langchain4j.ai.gemini.timeout=40000
+quarkus.langchain4j.ai.gemini.chat-model.model-id=gemini-2.5-flash

--- a/samples/java/agents/dice_agent_multi_transport/server/src/main/resources/application.properties
+++ b/samples/java/agents/dice_agent_multi_transport/server/src/main/resources/application.properties
@@ -2,3 +2,5 @@
 quarkus.grpc.server.use-separate-server=false
 quarkus.http.port=11000
 quarkus.langchain4j.ai.gemini.timeout=40000
+quarkus.langchain4j.ai.gemini.chat-model.model-id=gemini-2.5-flash
+

--- a/samples/java/agents/weather_mcp/src/main/resources/application.properties
+++ b/samples/java/agents/weather_mcp/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 quarkus.http.port=10001
 quarkus.langchain4j.mcp.weather.transport-type=stdio
 quarkus.langchain4j.mcp.weather.command=uv,--directory,mcp,run,weather_mcp.py
+quarkus.langchain4j.ai.gemini.chat-model.model-id=gemini-2.5-flash


### PR DESCRIPTION
# Description

This PR explicitly sets the Gemini chat model to use for the Java agents. The agents were previously relying on `gemini-1.5.-flash`, the [default Gemini chat model](https://github.com/quarkiverse/quarkus-langchain4j/issues/1819) set by Quarkus LangChain4j, but this chat model has been discontinued so updating these agents to use a newer chat model instead.

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
