### PR TITLE
test: broken unit test for go client send task streaming

### DIFF
--- a/samples/go/client/client_test.go
+++ b/samples/go/client/client_test.go
@@ -231,8 +231,8 @@ func TestSendTaskStreaming(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if req.Method != "message/send" {
-			t.Errorf("expected method message/send, got %s", req.Method)
+		if req.Method != "message/stream" {
+			t.Errorf("expected method message/stream, got %s", req.Method)
 		}
 
 		// Set response headers for streaming


### PR DESCRIPTION
# Description

The go client unit test sending `message/stream`, but the server expecting `message/send`. This PR fixes the method checking in server side.

before: 
<img width="609" height="157" alt="Screenshot 2025-09-28 at 09 23 19" src="https://github.com/user-attachments/assets/9fde3a18-a62b-4e3d-a3e8-55f1de1b07db" />

after:
<img width="489" height="442" alt="Screenshot 2025-09-28 at 09 23 51" src="https://github.com/user-attachments/assets/053e2dc2-3514-4aa7-9432-cf0f187fdbbd" />

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

