### PR TITLE
Fix API key loading logic to read directly from config file

### DIFF
--- a/samples/python/agents/travel_planner_agent/agent.py
+++ b/samples/python/agents/travel_planner_agent/agent.py
@@ -17,10 +17,10 @@ class TravelPlannerAgent:
         try:
             with open('config.json') as f:
                 config = json.load(f)
-            if not os.getenv(config['api_key']):
-                print(f'{config["api_key"]} environment variable not set.')
+            if not config['api_key']:
+                print('api_key configuration not set.')
                 sys.exit(1)
-            api_key = os.getenv(config['api_key'])
+            api_key = config['api_key']
 
             self.model = ChatOpenAI(
                 model=config['model_name'] or 'gpt-4o',


### PR DESCRIPTION
**Summary:**
This PR fixes a configuration issue where the agent attempted to read the API key as an environment variable name from `config.json`, causing initialization failures. The code now correctly loads the API key value directly from the configuration file and improves the error message for missing keys.

**Changes:**

* Removed environment variable lookup via `os.getenv(config['api_key'])`.
* Added direct assignment from `config['api_key']`.
* Updated error message to clearly indicate missing configuration.

**Impact:**
Ensures consistent API key loading from `config.json` and prevents false “environment variable not set” errors during agent initialization.
