### PR TITLE
chore: Upgrading to A2A java SDK 0.3.2.Final

### DIFF
--- a/samples/java/agents/pom.xml
+++ b/samples/java/agents/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- A2A SDK version - centralized for all agents -->
-        <io.a2a.sdk.version>0.3.0.Final</io.a2a.sdk.version>
+        <io.a2a.sdk.version>0.3.2.Final</io.a2a.sdk.version>
 
         <!-- Common dependency versions -->
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>


### PR DESCRIPTION
# Description
Updating the A2A java SDK version to the latest one currently aka 0.3.2.Final

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #400 🦕
