### PR TITLE
feat: Add Rust A2A implementation with framework and example agent

### DIFF
--- a/samples/rust/.gitignore
+++ b/samples/rust/.gitignore
@@ -1,0 +1,14 @@
+# Rust
+target/
+Cargo.lock
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -1,0 +1,44 @@
+[workspace]
+resolver = "2"
+members = [
+    "a2a-core",
+    "a2a-server",
+    "agents/hello_world",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+authors = ["A2A Contributors"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/google-a2a/a2a-samples"
+
+[workspace.dependencies]
+# Core A2A dependencies
+a2a-core = { path = "./a2a-core" }
+a2a-server = { path = "./a2a-server" }
+
+# Async runtime
+tokio = { version = "1.41", features = ["full"] }
+
+# HTTP server
+axum = { version = "0.7", features = ["macros"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors", "trace"] }
+
+# Serialization
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+# Error handling
+thiserror = "2.0"
+anyhow = "1.0"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Utilities
+uuid = { version = "1.11", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+async-trait = "0.1"

--- a/samples/rust/README.md
+++ b/samples/rust/README.md
@@ -1,0 +1,458 @@
+# Rust A2A Samples 🦀
+
+This directory contains Rust implementations of the Agent2Agent (A2A) Protocol, including a comprehensive framework for building A2A agents and example implementations.
+
+## Overview
+
+The Rust A2A implementation provides:
+
+- **a2a-core**: Core protocol types and structures (AgentCard, Task, Message, JSON-RPC, etc.)
+- **a2a-server**: HTTP server framework built on Axum for creating A2A agents
+- **agents/**: Example agent implementations
+
+## Architecture
+
+```
+rust/
+├── a2a-core/           # Core protocol types library
+├── a2a-server/         # HTTP server framework
+└── agents/
+    └── hello_world/    # Example Hello World agent
+```
+
+### Key Components
+
+#### a2a-core
+
+Core types for the A2A protocol:
+
+- **Types**: `AgentCard`, `Task`, `Message`, `Artifact`, `Part`, `TaskState`, etc.
+- **JSON-RPC**: Request/response structures and error handling
+- **Serialization**: Full serde support for JSON serialization
+
+#### a2a-server
+
+Server framework for building A2A agents:
+
+- **AgentExecutor**: Trait-based abstraction for implementing agent logic
+- **A2AServer**: HTTP server built on Axum with built-in JSON-RPC handling
+- **TaskStore**: Trait for task persistence with in-memory implementation
+- **EventQueue**: Async event system for agent communication
+
+## Prerequisites
+
+- **Rust**: 1.75 or later
+- **Cargo**: Rust's package manager (comes with Rust)
+
+Install Rust from [rustup.rs](https://rustup.rs/):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+## Getting Started
+
+### Running the Hello World Agent
+
+```bash
+cd agents/hello_world
+cargo run
+```
+
+The agent will start on `http://localhost:9999`.
+
+### Testing the Agent
+
+Get the agent card:
+
+```bash
+curl http://localhost:9999/agent-card
+```
+
+Send a message:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "id": "task-123",
+      "message": {
+        "role": "user",
+        "parts": [
+          {
+            "type": "text",
+            "text": "hello"
+          }
+        ]
+      }
+    }
+  }'
+```
+
+Get task status:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "tasks/get",
+    "params": {
+      "id": "task-123"
+    }
+  }'
+```
+
+## Creating Your Own Agent
+
+### 1. Add to Workspace
+
+Create a new directory in `agents/`:
+
+```bash
+mkdir -p agents/my_agent/src
+```
+
+Create `agents/my_agent/Cargo.toml`:
+
+```toml
+[package]
+name = "my_agent"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "my_agent"
+path = "src/main.rs"
+
+[dependencies]
+a2a-core = { workspace = true }
+a2a-server = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+```
+
+Update the root `Cargo.toml` to include your agent:
+
+```toml
+[workspace]
+members = [
+    "a2a-core",
+    "a2a-server",
+    "agents/hello_world",
+    "agents/my_agent",  # Add this line
+]
+```
+
+### 2. Implement AgentExecutor
+
+Create `agents/my_agent/src/main.rs`:
+
+```rust
+use a2a_core::types::{AgentCard, AgentCapabilities, AgentSkill, Message, Task};
+use a2a_server::{
+    executor::{AgentExecutor, EventQueue, RequestContext},
+    store::InMemoryTaskStore,
+    A2AServer,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+struct MyAgent;
+
+#[async_trait]
+impl AgentExecutor for MyAgent {
+    async fn execute(
+        &self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> anyhow::Result<()> {
+        // Your agent logic here
+        tracing::info!("Processing task: {}", context.task_id);
+
+        // Extract user message
+        let user_text = context
+            .message
+            .parts
+            .iter()
+            .find_map(|part| part.text.as_ref())
+            .unwrap_or(&"".to_string());
+
+        // Process and generate response
+        let response_text = format!("You said: {}", user_text);
+        let response = Message::agent_text(response_text);
+
+        // Send response
+        event_queue.send_message(response).await?;
+
+        // Complete task
+        let task = Task::new(context.task_id).complete();
+        event_queue.send_completed(task).await?;
+
+        Ok(())
+    }
+
+    async fn cancel(&self, _context: RequestContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let agent_card = AgentCard {
+        name: "My Agent".to_string(),
+        description: Some("My custom A2A agent".to_string()),
+        url: "http://localhost:9999".to_string(),
+        version: "1.0.0".to_string(),
+        capabilities: AgentCapabilities::default(),
+        authentication: None,
+        provider: None,
+        documentation_url: None,
+        default_input_modes: Some(vec!["text".to_string()]),
+        default_output_modes: Some(vec!["text".to_string()]),
+        skills: vec![
+            AgentSkill {
+                id: "echo".to_string(),
+                name: "Echo messages".to_string(),
+                description: Some("Echoes back your message".to_string()),
+                tags: None,
+                examples: Some(vec!["hello".to_string()]),
+                input_modes: None,
+                output_modes: None,
+            }
+        ],
+    };
+
+    let server = A2AServer::new(
+        agent_card,
+        Arc::new(MyAgent),
+        Arc::new(InMemoryTaskStore::new()),
+    )
+    .with_port(9999);
+
+    server.run().await
+}
+```
+
+### 3. Run Your Agent
+
+```bash
+cd agents/my_agent
+cargo run
+```
+
+## Advanced Features
+
+### Adding External APIs (e.g., Grok SDK)
+
+To integrate external APIs like the Grok SDK:
+
+```toml
+# Add to your agent's Cargo.toml
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+```
+
+```rust
+use reqwest::Client;
+
+struct GrokAgent {
+    client: Client,
+    api_key: String,
+}
+
+#[async_trait]
+impl AgentExecutor for GrokAgent {
+    async fn execute(
+        &self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> anyhow::Result<()> {
+        // Call Grok API
+        let response = self.client
+            .post("https://api.grok.com/v1/chat")
+            .bearer_auth(&self.api_key)
+            .json(&serde_json::json!({
+                "message": context.message
+            }))
+            .send()
+            .await?;
+
+        // Process response and send via event queue
+        let grok_response = response.json::<YourResponseType>().await?;
+        event_queue.send_message(Message::agent_text(grok_response.text)).await?;
+
+        let task = Task::new(context.task_id).complete();
+        event_queue.send_completed(task).await?;
+
+        Ok(())
+    }
+
+    async fn cancel(&self, _context: RequestContext) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+```
+
+### Streaming Support
+
+For streaming responses, send multiple messages via the event queue:
+
+```rust
+async fn execute(
+    &self,
+    context: RequestContext,
+    event_queue: EventQueue,
+) -> anyhow::Result<()> {
+    // Send chunks as they arrive
+    for chunk in stream {
+        let msg = Message::agent_text(chunk);
+        event_queue.send_message(msg).await?;
+    }
+
+    // Mark complete when done
+    let task = Task::new(context.task_id).complete();
+    event_queue.send_completed(task).await?;
+
+    Ok(())
+}
+```
+
+### Custom Task Storage
+
+Implement the `TaskStore` trait for persistent storage:
+
+```rust
+use a2a_server::store::TaskStore;
+use async_trait::async_trait;
+
+struct DatabaseTaskStore {
+    // Your database connection
+}
+
+#[async_trait]
+impl TaskStore for DatabaseTaskStore {
+    async fn store_task(&self, task: Task) -> anyhow::Result<()> {
+        // Store in database
+        Ok(())
+    }
+
+    async fn get_task(&self, id: &str) -> anyhow::Result<Option<Task>> {
+        // Retrieve from database
+        Ok(None)
+    }
+
+    // Implement other methods...
+}
+```
+
+## Building for Production
+
+### Build optimized binary:
+
+```bash
+cargo build --release
+```
+
+Binary will be in `target/release/`.
+
+### Using Docker
+
+Create a `Dockerfile` in your agent directory:
+
+```dockerfile
+FROM rust:1.75 as builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/my_agent /usr/local/bin/
+CMD ["my_agent"]
+```
+
+Build and run:
+
+```bash
+docker build -t my-a2a-agent .
+docker run -p 9999:9999 my-a2a-agent
+```
+
+## Development
+
+### Running tests:
+
+```bash
+cargo test
+```
+
+### Checking code:
+
+```bash
+cargo check
+cargo clippy
+cargo fmt
+```
+
+### Building documentation:
+
+```bash
+cargo doc --open
+```
+
+## API Reference
+
+### Core Types
+
+- **AgentCard**: Metadata describing the agent
+- **Task**: Represents a task being processed
+- **Message**: A message in the conversation
+- **Part**: A part of a message (text, file, data)
+- **Artifact**: Output from a task
+
+### Server Components
+
+- **AgentExecutor**: Main trait for implementing agent logic
+- **EventQueue**: Send events during execution
+- **TaskStore**: Store and retrieve tasks
+- **A2AServer**: HTTP server for the agent
+
+### JSON-RPC Methods
+
+Supported methods:
+- `message/send`: Send a message to the agent
+- `tasks/get`: Get task status
+- `tasks/cancel`: Cancel a task
+
+## Examples
+
+See the `agents/` directory for complete examples:
+
+- **hello_world**: Simple greeting agent
+
+## Resources
+
+- [A2A Protocol Specification](https://github.com/google-a2a/a2a)
+- [A2A Samples Repository](https://github.com/google-a2a/a2a-samples)
+- [Rust Documentation](https://doc.rust-lang.org/)
+- [Axum Documentation](https://docs.rs/axum/)
+- [Tokio Documentation](https://tokio.rs/)
+
+## Contributing
+
+Contributions are welcome! Please follow the standard Rust coding conventions and ensure all tests pass.
+
+## License
+
+MIT OR Apache-2.0

--- a/samples/rust/a2a-core/Cargo.toml
+++ b/samples/rust/a2a-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "a2a-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+
+[dev-dependencies]

--- a/samples/rust/a2a-core/src/error.rs
+++ b/samples/rust/a2a-core/src/error.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+/// Core A2A errors
+#[derive(Debug, Error)]
+pub enum A2AError {
+    #[error("Serialization error: {0}")]
+    SerializationError(#[from] serde_json::Error),
+
+    #[error("Task not found: {0}")]
+    TaskNotFound(String),
+
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Invalid parameters: {0}")]
+    InvalidParams(String),
+
+    #[error("Method not found: {0}")]
+    MethodNotFound(String),
+
+    #[error("Internal error: {0}")]
+    InternalError(String),
+
+    #[error("Custom error: {0}")]
+    Custom(String),
+}
+
+pub type Result<T> = std::result::Result<T, A2AError>;

--- a/samples/rust/a2a-core/src/jsonrpc.rs
+++ b/samples/rust/a2a-core/src/jsonrpc.rs
@@ -1,0 +1,207 @@
+use crate::types::{Message, Task, TaskHistory};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// JSON-RPC version constant
+pub const JSONRPC_VERSION: &str = "2.0";
+
+/// JSON-RPC error codes
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    ParseError = -32700,
+    InvalidRequest = -32600,
+    MethodNotFound = -32601,
+    InvalidParams = -32602,
+    InternalError = -32603,
+    TaskNotFound = -32001,
+}
+
+impl ErrorCode {
+    pub fn as_i32(self) -> i32 {
+        self as i32
+    }
+}
+
+/// JSON-RPC request ID (can be string, number, or null)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum RequestId {
+    String(String),
+    Number(i64),
+    Null,
+}
+
+impl From<String> for RequestId {
+    fn from(s: String) -> Self {
+        RequestId::String(s)
+    }
+}
+
+impl From<i64> for RequestId {
+    fn from(n: i64) -> Self {
+        RequestId::Number(n)
+    }
+}
+
+/// JSON-RPC request
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<RequestId>,
+    pub method: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+}
+
+/// JSON-RPC error object
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code: code.as_i32(),
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub fn with_data(mut self, data: Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+
+    pub fn parse_error(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::ParseError, message)
+    }
+
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidRequest, message)
+    }
+
+    pub fn method_not_found(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::MethodNotFound, message)
+    }
+
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidParams, message)
+    }
+
+    pub fn internal_error(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InternalError, message)
+    }
+
+    pub fn task_not_found(message: impl Into<String>) -> Self {
+        Self::new(ErrorCode::TaskNotFound, message)
+    }
+}
+
+/// JSON-RPC response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: RequestId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+impl JsonRpcResponse {
+    pub fn success(id: RequestId, result: Value) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: RequestId, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id,
+            result: None,
+            error: Some(error),
+        }
+    }
+}
+
+/// Parameters for sending a task message
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSendParams {
+    /// Unique identifier for the task
+    pub id: String,
+    /// Optional identifier for the session this task belongs to
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Message content to send to the agent
+    pub message: Message,
+    /// Optional push notification information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_notification: Option<PushNotificationConfig>,
+    /// Optional parameter to specify how much message history to include
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_length: Option<i32>,
+    /// Optional metadata associated with sending this message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
+}
+
+/// Base parameters for task ID-based operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskIdParams {
+    /// Unique identifier of the task
+    pub id: String,
+    /// Optional metadata to include with the operation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
+}
+
+/// Parameters for querying task information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskQueryParams {
+    #[serde(flatten)]
+    pub base: TaskIdParams,
+    /// Optional parameter to specify how much history to retrieve
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_length: Option<i32>,
+}
+
+/// Configuration for push notifications
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PushNotificationConfig {
+    /// Endpoint where the agent should send notifications
+    pub url: String,
+    /// Token to be included in push notification requests for verification
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+}
+
+/// Response for task operations (with optional history)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskResponse {
+    #[serde(flatten)]
+    pub task: Task,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<TaskHistory>,
+}
+
+/// Streaming response wrapper
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamingResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}

--- a/samples/rust/a2a-core/src/lib.rs
+++ b/samples/rust/a2a-core/src/lib.rs
@@ -1,0 +1,58 @@
+//! # A2A Core
+//!
+//! Core types and utilities for the Agent2Agent (A2A) Protocol.
+//!
+//! This crate provides the foundational types and structures needed to implement
+//! A2A agents and clients, including:
+//!
+//! - Protocol types: `AgentCard`, `Task`, `Message`, `Artifact`, etc.
+//! - JSON-RPC types: Request, response, and error structures
+//! - Error handling types
+//!
+//! ## Example
+//!
+//! ```rust
+//! use a2a_core::types::{AgentCard, AgentCapabilities, AgentSkill};
+//!
+//! let skill = AgentSkill {
+//!     id: "hello".to_string(),
+//!     name: "Hello World".to_string(),
+//!     description: Some("Returns a greeting".to_string()),
+//!     tags: None,
+//!     examples: Some(vec!["hi".to_string(), "hello".to_string()]),
+//!     input_modes: None,
+//!     output_modes: None,
+//! };
+//!
+//! let card = AgentCard {
+//!     name: "Hello Agent".to_string(),
+//!     description: Some("A simple greeting agent".to_string()),
+//!     url: "http://localhost:9999".to_string(),
+//!     provider: None,
+//!     version: "1.0.0".to_string(),
+//!     documentation_url: None,
+//!     capabilities: AgentCapabilities {
+//!         streaming: Some(true),
+//!         ..Default::default()
+//!     },
+//!     authentication: None,
+//!     default_input_modes: Some(vec!["text".to_string()]),
+//!     default_output_modes: Some(vec!["text".to_string()]),
+//!     skills: vec![skill],
+//! };
+//! ```
+
+pub mod error;
+pub mod jsonrpc;
+pub mod types;
+
+// Re-export commonly used types
+pub use error::{A2AError, Result};
+pub use jsonrpc::{
+    ErrorCode, JsonRpcError, JsonRpcRequest, JsonRpcResponse, RequestId, TaskIdParams,
+    TaskQueryParams, TaskSendParams, JSONRPC_VERSION,
+};
+pub use types::{
+    AgentCapabilities, AgentCard, AgentSkill, Artifact, Message, Part, Task, TaskState,
+    TaskStatus,
+};

--- a/samples/rust/a2a-core/src/types.rs
+++ b/samples/rust/a2a-core/src/types.rs
@@ -1,0 +1,332 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Task state within the A2A protocol
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskState {
+    Submitted,
+    Working,
+    InputRequired,
+    Completed,
+    Canceled,
+    Failed,
+    Unknown,
+}
+
+/// Authentication schemes and credentials for an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentAuthentication {
+    /// List of supported authentication schemes
+    pub schemes: Vec<String>,
+    /// Credentials for authentication (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<String>,
+}
+
+/// Capabilities of an agent
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    /// Indicates if the agent supports streaming responses
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+    /// Indicates if the agent supports push notifications
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_notifications: Option<bool>,
+    /// Indicates if the agent supports state transition history
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_transition_history: Option<bool>,
+}
+
+/// Provider or organization behind an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentProvider {
+    /// Name of the organization providing the agent
+    pub organization: String,
+    /// URL associated with the agent provider
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+/// A specific skill or capability offered by an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkill {
+    /// Unique identifier for the skill
+    pub id: String,
+    /// Human-readable name of the skill
+    pub name: String,
+    /// Optional description of the skill
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional list of tags for categorization
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    /// Optional list of example inputs or use cases
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<Vec<String>>,
+    /// Optional list of input modes supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modes: Option<Vec<String>>,
+    /// Optional list of output modes supported
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_modes: Option<Vec<String>>,
+}
+
+/// Metadata card for an agent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCard {
+    /// Name of the agent
+    pub name: String,
+    /// Optional description of the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Base URL endpoint for interacting with the agent
+    pub url: String,
+    /// Information about the provider of the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<AgentProvider>,
+    /// Version identifier for the agent or its API
+    pub version: String,
+    /// Optional URL pointing to the agent's documentation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+    /// Capabilities supported by the agent
+    pub capabilities: AgentCapabilities,
+    /// Authentication details required to interact with the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<AgentAuthentication>,
+    /// Default input modes supported by the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_input_modes: Option<Vec<String>>,
+    /// Default output modes supported by the agent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_output_modes: Option<Vec<String>>,
+    /// List of specific skills offered by the agent
+    pub skills: Vec<AgentSkill>,
+}
+
+/// Base structure for file content
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileContentBase {
+    /// Optional name of the file
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Optional MIME type of the file content
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+}
+
+/// File content as base64-encoded bytes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileContentBytes {
+    #[serde(flatten)]
+    pub base: FileContentBase,
+    /// File content encoded as a Base64 string
+    pub bytes: String,
+}
+
+/// File content as a URI
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileContentUri {
+    #[serde(flatten)]
+    pub base: FileContentBase,
+    /// URI pointing to the file content
+    pub uri: String,
+}
+
+/// File content (either bytes or URI-based)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FileContent {
+    Bytes(FileContentBytes),
+    Uri(FileContentUri),
+}
+
+/// A part of a message or artifact
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Part {
+    /// Type identifier for this part
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub part_type: Option<String>,
+    /// Text content for text parts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// File content for file parts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<FileContent>,
+    /// Structured data content for data parts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<HashMap<String, serde_json::Value>>,
+    /// Optional metadata associated with this part
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl Part {
+    /// Create a text part
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            part_type: Some("text".to_string()),
+            text: Some(text.into()),
+            file: None,
+            data: None,
+            metadata: None,
+        }
+    }
+}
+
+/// An output or intermediate file from a task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Artifact {
+    /// Optional name for the artifact
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Optional description of the artifact
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Constituent parts of the artifact
+    pub parts: Vec<Part>,
+    /// Optional index for ordering artifacts
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<i32>,
+    /// Indicates if this artifact content should append to previous content
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<bool>,
+    /// Optional metadata associated with the artifact
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+    /// Indicates if this is the last chunk of data for this artifact
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_chunk: Option<bool>,
+}
+
+/// Status of a task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskStatus {
+    pub state: TaskState,
+}
+
+/// An A2A task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    pub id: String,
+    pub status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<Artifact>>,
+}
+
+impl Task {
+    /// Create a new task with the given ID
+    pub fn new(id: String) -> Self {
+        Self {
+            id,
+            status: TaskStatus {
+                state: TaskState::Working,
+            },
+            artifacts: None,
+        }
+    }
+
+    /// Mark task as completed
+    pub fn complete(mut self) -> Self {
+        self.status.state = TaskState::Completed;
+        self
+    }
+
+    /// Mark task as failed
+    pub fn fail(mut self) -> Self {
+        self.status.state = TaskState::Failed;
+        self
+    }
+
+    /// Add an artifact to the task
+    pub fn with_artifact(mut self, artifact: Artifact) -> Self {
+        self.artifacts
+            .get_or_insert_with(Vec::new)
+            .push(artifact);
+        self
+    }
+}
+
+/// A message in the A2A protocol
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub parts: Vec<Part>,
+}
+
+impl Message {
+    /// Create a new message with the given role
+    pub fn new(role: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            parts: Vec::new(),
+        }
+    }
+
+    /// Add a text part to the message
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.parts.push(Part::text(text));
+        self
+    }
+
+    /// Add a part to the message
+    pub fn with_part(mut self, part: Part) -> Self {
+        self.parts.push(part);
+        self
+    }
+
+    /// Create an agent message with text
+    pub fn agent_text(text: impl Into<String>) -> Self {
+        Self::new("agent").with_text(text)
+    }
+
+    /// Create a user message with text
+    pub fn user_text(text: impl Into<String>) -> Self {
+        Self::new("user").with_text(text)
+    }
+}
+
+/// History of a task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskHistory {
+    /// List of messages in chronological order
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_history: Option<Vec<Message>>,
+}
+
+/// Event for task status updates
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskStatusUpdateEvent {
+    /// ID of the task being updated
+    pub id: String,
+    /// New status of the task
+    pub status: TaskStatus,
+    /// Indicates if this is the final update for the task
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_: Option<bool>,
+    /// Optional metadata associated with this update event
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Event for task artifact updates
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskArtifactUpdateEvent {
+    /// ID of the task being updated
+    pub id: String,
+    /// New or updated artifact for the task
+    pub artifact: Artifact,
+    /// Indicates if this is the final update for the task
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_: Option<bool>,
+    /// Optional metadata associated with this update event
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, serde_json::Value>>,
+}

--- a/samples/rust/a2a-server/Cargo.toml
+++ b/samples/rust/a2a-server/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "a2a-server"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+a2a-core = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# HTTP server
+axum = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Error handling
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# Utilities
+uuid = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]

--- a/samples/rust/a2a-server/src/executor.rs
+++ b/samples/rust/a2a-server/src/executor.rs
@@ -1,0 +1,126 @@
+use a2a_core::types::{Message, Task};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+/// Events that can be emitted during agent execution
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    /// A message from the agent
+    Message(Message),
+    /// Task status update
+    StatusUpdate(Task),
+    /// Task completed
+    Completed(Task),
+    /// Task failed
+    Failed(String),
+}
+
+/// Event queue for agent execution
+pub struct EventQueue {
+    sender: mpsc::UnboundedSender<AgentEvent>,
+}
+
+impl EventQueue {
+    pub(crate) fn new(sender: mpsc::UnboundedSender<AgentEvent>) -> Self {
+        Self { sender }
+    }
+
+    /// Enqueue an event
+    pub async fn send(&self, event: AgentEvent) -> anyhow::Result<()> {
+        self.sender
+            .send(event)
+            .map_err(|e| anyhow::anyhow!("Failed to send event: {}", e))
+    }
+
+    /// Send a message event
+    pub async fn send_message(&self, message: Message) -> anyhow::Result<()> {
+        self.send(AgentEvent::Message(message)).await
+    }
+
+    /// Send a status update event
+    pub async fn send_status_update(&self, task: Task) -> anyhow::Result<()> {
+        self.send(AgentEvent::StatusUpdate(task)).await
+    }
+
+    /// Send a completion event
+    pub async fn send_completed(&self, task: Task) -> anyhow::Result<()> {
+        self.send(AgentEvent::Completed(task)).await
+    }
+
+    /// Send a failure event
+    pub async fn send_failed(&self, error: String) -> anyhow::Result<()> {
+        self.send(AgentEvent::Failed(error)).await
+    }
+}
+
+/// Context for agent execution
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    /// Task ID
+    pub task_id: String,
+    /// Session ID (if provided)
+    pub session_id: Option<String>,
+    /// Incoming message
+    pub message: Message,
+    /// Message history
+    pub history: Vec<Message>,
+}
+
+/// Trait for implementing agent executors
+///
+/// Implement this trait to create your custom agent logic.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use a2a_server::executor::{AgentExecutor, RequestContext, EventQueue, AgentEvent};
+/// use a2a_core::types::Message;
+/// use async_trait::async_trait;
+///
+/// struct MyAgent;
+///
+/// #[async_trait]
+/// impl AgentExecutor for MyAgent {
+///     async fn execute(&self, context: RequestContext, event_queue: EventQueue) -> anyhow::Result<()> {
+///         // Process the message
+///         let response = Message::agent_text("Hello from my agent!");
+///
+///         // Send response
+///         event_queue.send_message(response).await?;
+///
+///         // Mark as complete
+///         let task = a2a_core::types::Task::new(context.task_id).complete();
+///         event_queue.send_completed(task).await?;
+///
+///         Ok(())
+///     }
+///
+///     async fn cancel(&self, context: RequestContext) -> anyhow::Result<()> {
+///         // Handle cancellation
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait AgentExecutor: Send + Sync {
+    /// Execute the agent logic
+    ///
+    /// This method is called when a new task is received. The agent should:
+    /// 1. Process the incoming message
+    /// 2. Send events via the event queue (messages, status updates)
+    /// 3. Send a completion or failure event when done
+    async fn execute(
+        &self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> anyhow::Result<()>;
+
+    /// Cancel an ongoing task
+    ///
+    /// This method is called when a task cancellation is requested.
+    async fn cancel(&self, context: RequestContext) -> anyhow::Result<()>;
+}
+
+/// Type alias for Arc-wrapped agent executor
+pub type AgentExecutorRef = Arc<dyn AgentExecutor>;

--- a/samples/rust/a2a-server/src/handler.rs
+++ b/samples/rust/a2a-server/src/handler.rs
@@ -1,0 +1,280 @@
+use crate::executor::{AgentEvent, EventQueue, RequestContext};
+use crate::store::TaskStoreRef;
+use a2a_core::jsonrpc::{
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, RequestId, TaskIdParams, TaskQueryParams,
+    TaskSendParams,
+};
+use a2a_core::types::{Artifact, Message, Task, TaskState};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use crate::executor::AgentExecutorRef;
+
+/// Request handler for A2A JSON-RPC requests
+pub struct RequestHandler {
+    executor: AgentExecutorRef,
+    task_store: TaskStoreRef,
+}
+
+impl RequestHandler {
+    pub fn new(executor: AgentExecutorRef, task_store: TaskStoreRef) -> Self {
+        Self {
+            executor,
+            task_store,
+        }
+    }
+
+    /// Handle a JSON-RPC request
+    pub async fn handle(&self, request: JsonRpcRequest) -> JsonRpcResponse {
+        let id = request.id.clone().unwrap_or(RequestId::Null);
+
+        match request.method.as_str() {
+            "message/send" => self.handle_message_send(request, id).await,
+            "tasks/get" => self.handle_task_get(request, id).await,
+            "tasks/cancel" => self.handle_task_cancel(request, id).await,
+            _ => JsonRpcResponse::error(
+                id,
+                JsonRpcError::method_not_found(format!("Method not found: {}", request.method)),
+            ),
+        }
+    }
+
+    async fn handle_message_send(
+        &self,
+        request: JsonRpcRequest,
+        id: RequestId,
+    ) -> JsonRpcResponse {
+        // Parse parameters
+        let params: TaskSendParams = match request.params {
+            Some(params) => match serde_json::from_value(params) {
+                Ok(p) => p,
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        id,
+                        JsonRpcError::invalid_params(format!("Invalid parameters: {}", e)),
+                    )
+                }
+            },
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    JsonRpcError::invalid_params("Missing parameters"),
+                )
+            }
+        };
+
+        // Create task
+        let mut task = Task::new(params.id.clone());
+
+        // Store initial message
+        if let Err(e) = self.task_store.store_message(&task.id, params.message.clone()).await {
+            return JsonRpcResponse::error(
+                id,
+                JsonRpcError::internal_error(format!("Failed to store message: {}", e)),
+            );
+        }
+
+        // Store task
+        if let Err(e) = self.task_store.store_task(task.clone()).await {
+            return JsonRpcResponse::error(
+                id,
+                JsonRpcError::internal_error(format!("Failed to store task: {}", e)),
+            );
+        }
+
+        // Get history
+        let history = self
+            .task_store
+            .get_history(&task.id)
+            .await
+            .unwrap_or_default();
+
+        // Create context
+        let context = RequestContext {
+            task_id: params.id.clone(),
+            session_id: params.session_id.clone(),
+            message: params.message.clone(),
+            history,
+        };
+
+        // Create event queue
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let event_queue = EventQueue::new(tx);
+
+        // Clone executor and task store for the async task
+        let executor = Arc::clone(&self.executor);
+        let task_store = Arc::clone(&self.task_store);
+        let task_id = params.id.clone();
+
+        // Execute agent in background
+        tokio::spawn(async move {
+            if let Err(e) = executor.execute(context, event_queue).await {
+                tracing::error!("Agent execution failed: {}", e);
+            }
+
+            // Process events
+            while let Some(event) = rx.recv().await {
+                match event {
+                    AgentEvent::Message(msg) => {
+                        // Store message
+                        if let Err(e) = task_store.store_message(&task_id, msg.clone()).await {
+                            tracing::error!("Failed to store message: {}", e);
+                        }
+
+                        // Update task with artifact
+                        if let Ok(Some(mut task)) = task_store.get_task(&task_id).await {
+                            let artifact = message_to_artifact(msg);
+                            task = task.with_artifact(artifact);
+                            if let Err(e) = task_store.update_task(task).await {
+                                tracing::error!("Failed to update task: {}", e);
+                            }
+                        }
+                    }
+                    AgentEvent::StatusUpdate(updated_task) => {
+                        if let Err(e) = task_store.update_task(updated_task).await {
+                            tracing::error!("Failed to update task: {}", e);
+                        }
+                    }
+                    AgentEvent::Completed(completed_task) => {
+                        if let Err(e) = task_store.update_task(completed_task).await {
+                            tracing::error!("Failed to update task: {}", e);
+                        }
+                        break;
+                    }
+                    AgentEvent::Failed(error) => {
+                        if let Ok(Some(mut task)) = task_store.get_task(&task_id).await {
+                            task.status.state = TaskState::Failed;
+                            if let Err(e) = task_store.update_task(task).await {
+                                tracing::error!("Failed to update task: {}", e);
+                            }
+                        }
+                        tracing::error!("Task failed: {}", error);
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Wait a bit for the task to be updated
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Get updated task
+        task = self
+            .task_store
+            .get_task(&params.id)
+            .await
+            .unwrap_or(Some(task))
+            .unwrap();
+
+        JsonRpcResponse::success(id, serde_json::to_value(&task).unwrap())
+    }
+
+    async fn handle_task_get(&self, request: JsonRpcRequest, id: RequestId) -> JsonRpcResponse {
+        let params: TaskQueryParams = match request.params {
+            Some(params) => match serde_json::from_value(params) {
+                Ok(p) => p,
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        id,
+                        JsonRpcError::invalid_params(format!("Invalid parameters: {}", e)),
+                    )
+                }
+            },
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    JsonRpcError::invalid_params("Missing parameters"),
+                )
+            }
+        };
+
+        match self.task_store.get_task(&params.base.id).await {
+            Ok(Some(task)) => JsonRpcResponse::success(id, serde_json::to_value(&task).unwrap()),
+            Ok(None) => {
+                JsonRpcResponse::error(id, JsonRpcError::task_not_found("Task not found"))
+            }
+            Err(e) => JsonRpcResponse::error(
+                id,
+                JsonRpcError::internal_error(format!("Failed to get task: {}", e)),
+            ),
+        }
+    }
+
+    async fn handle_task_cancel(&self, request: JsonRpcRequest, id: RequestId) -> JsonRpcResponse {
+        let params: TaskIdParams = match request.params {
+            Some(params) => match serde_json::from_value(params) {
+                Ok(p) => p,
+                Err(e) => {
+                    return JsonRpcResponse::error(
+                        id,
+                        JsonRpcError::invalid_params(format!("Invalid parameters: {}", e)),
+                    )
+                }
+            },
+            None => {
+                return JsonRpcResponse::error(
+                    id,
+                    JsonRpcError::invalid_params("Missing parameters"),
+                )
+            }
+        };
+
+        // Get task
+        let mut task = match self.task_store.get_task(&params.id).await {
+            Ok(Some(task)) => task,
+            Ok(None) => {
+                return JsonRpcResponse::error(id, JsonRpcError::task_not_found("Task not found"))
+            }
+            Err(e) => {
+                return JsonRpcResponse::error(
+                    id,
+                    JsonRpcError::internal_error(format!("Failed to get task: {}", e)),
+                )
+            }
+        };
+
+        // Update task status
+        task.status.state = TaskState::Canceled;
+
+        // Store updated task
+        if let Err(e) = self.task_store.update_task(task.clone()).await {
+            return JsonRpcResponse::error(
+                id,
+                JsonRpcError::internal_error(format!("Failed to update task: {}", e)),
+            );
+        }
+
+        // Call executor cancel
+        let history = self
+            .task_store
+            .get_history(&params.id)
+            .await
+            .unwrap_or_default();
+
+        let context = RequestContext {
+            task_id: params.id.clone(),
+            session_id: None,
+            message: Message::new("system").with_text("cancel"),
+            history,
+        };
+
+        if let Err(e) = self.executor.cancel(context).await {
+            tracing::error!("Failed to cancel task: {}", e);
+        }
+
+        JsonRpcResponse::success(id, serde_json::to_value(&task).unwrap())
+    }
+}
+
+/// Helper function to convert a message to an artifact
+fn message_to_artifact(message: Message) -> Artifact {
+    Artifact {
+        name: Some(format!("{} message", message.role)),
+        description: None,
+        parts: message.parts,
+        index: None,
+        append: None,
+        metadata: None,
+        last_chunk: Some(true),
+    }
+}

--- a/samples/rust/a2a-server/src/lib.rs
+++ b/samples/rust/a2a-server/src/lib.rs
@@ -1,0 +1,72 @@
+//! # A2A Server
+//!
+//! HTTP server framework for building Agent2Agent (A2A) protocol agents in Rust.
+//!
+//! This crate provides:
+//!
+//! - `AgentExecutor` trait: Define your agent's logic
+//! - `A2AServer`: HTTP server built on Axum
+//! - `TaskStore` trait: Persist tasks and message history
+//! - `InMemoryTaskStore`: Simple in-memory task storage
+//!
+//! ## Quick Start
+//!
+//! ```rust,ignore
+//! use a2a_server::{A2AServer, executor::{AgentExecutor, RequestContext, EventQueue}, store::InMemoryTaskStore};
+//! use a2a_core::types::{AgentCard, AgentCapabilities, AgentSkill, Message};
+//! use async_trait::async_trait;
+//! use std::sync::Arc;
+//!
+//! // 1. Implement your agent
+//! struct MyAgent;
+//!
+//! #[async_trait]
+//! impl AgentExecutor for MyAgent {
+//!     async fn execute(&self, context: RequestContext, event_queue: EventQueue) -> anyhow::Result<()> {
+//!         // Your agent logic here
+//!         let response = Message::agent_text("Hello!");
+//!         event_queue.send_message(response).await?;
+//!
+//!         let task = a2a_core::types::Task::new(context.task_id).complete();
+//!         event_queue.send_completed(task).await?;
+//!         Ok(())
+//!     }
+//!
+//!     async fn cancel(&self, _context: RequestContext) -> anyhow::Result<()> {
+//!         Ok(())
+//!     }
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     // 2. Create your agent card
+//!     let agent_card = AgentCard {
+//!         name: "My Agent".to_string(),
+//!         description: Some("A simple agent".to_string()),
+//!         url: "http://localhost:9999".to_string(),
+//!         version: "1.0.0".to_string(),
+//!         capabilities: AgentCapabilities::default(),
+//!         skills: vec![],
+//!         // ... other fields
+//!     };
+//!
+//!     // 3. Create and run the server
+//!     let server = A2AServer::new(
+//!         agent_card,
+//!         Arc::new(MyAgent),
+//!         Arc::new(InMemoryTaskStore::new()),
+//!     );
+//!
+//!     server.run().await
+//! }
+//! ```
+
+pub mod executor;
+pub mod handler;
+pub mod server;
+pub mod store;
+
+// Re-export commonly used types
+pub use executor::{AgentEvent, AgentExecutor, AgentExecutorRef, EventQueue, RequestContext};
+pub use server::A2AServer;
+pub use store::{InMemoryTaskStore, TaskStore, TaskStoreRef};

--- a/samples/rust/a2a-server/src/server.rs
+++ b/samples/rust/a2a-server/src/server.rs
@@ -1,0 +1,143 @@
+use crate::executor::AgentExecutorRef;
+use crate::handler::RequestHandler;
+use crate::store::TaskStoreRef;
+use a2a_core::jsonrpc::{JsonRpcRequest, JsonRpcResponse};
+use a2a_core::types::AgentCard;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use std::sync::Arc;
+use tower_http::cors::CorsLayer;
+
+/// A2A server state
+#[derive(Clone)]
+pub struct A2AServerState {
+    agent_card: Arc<AgentCard>,
+    handler: Arc<RequestHandler>,
+}
+
+/// A2A Server
+pub struct A2AServer {
+    agent_card: AgentCard,
+    executor: AgentExecutorRef,
+    task_store: TaskStoreRef,
+    host: String,
+    port: u16,
+}
+
+impl A2AServer {
+    /// Create a new A2A server
+    pub fn new(
+        agent_card: AgentCard,
+        executor: AgentExecutorRef,
+        task_store: TaskStoreRef,
+    ) -> Self {
+        Self {
+            agent_card,
+            executor,
+            task_store,
+            host: "0.0.0.0".to_string(),
+            port: 9999,
+        }
+    }
+
+    /// Set the host address
+    pub fn with_host(mut self, host: impl Into<String>) -> Self {
+        self.host = host.into();
+        self
+    }
+
+    /// Set the port
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Build and return the Axum router
+    pub fn build_router(&self) -> Router {
+        let handler = Arc::new(RequestHandler::new(
+            Arc::clone(&self.executor),
+            Arc::clone(&self.task_store),
+        ));
+
+        let state = A2AServerState {
+            agent_card: Arc::new(self.agent_card.clone()),
+            handler,
+        };
+
+        Router::new()
+            .route("/", post(handle_jsonrpc))
+            .route("/agent-card", get(handle_agent_card))
+            .route("/health", get(handle_health))
+            .with_state(state)
+            .layer(CorsLayer::permissive())
+    }
+
+    /// Run the server
+    pub async fn run(self) -> anyhow::Result<()> {
+        let addr = format!("{}:{}", self.host, self.port);
+        let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+        tracing::info!("🦀 A2A Server listening on http://{}", addr);
+        tracing::info!("📋 Agent Card: {}", self.agent_card.name);
+        tracing::info!("🔗 Agent URL: {}", self.agent_card.url);
+
+        let router = self.build_router();
+
+        axum::serve(listener, router).await?;
+
+        Ok(())
+    }
+}
+
+/// Handle JSON-RPC requests
+async fn handle_jsonrpc(
+    State(state): State<A2AServerState>,
+    Json(request): Json<JsonRpcRequest>,
+) -> Result<Json<JsonRpcResponse>, AppError> {
+    tracing::debug!("Received JSON-RPC request: {:?}", request);
+
+    let response = state.handler.handle(request).await;
+
+    tracing::debug!("Sending JSON-RPC response: {:?}", response);
+
+    Ok(Json(response))
+}
+
+/// Handle agent card requests
+async fn handle_agent_card(
+    State(state): State<A2AServerState>,
+) -> Result<Json<AgentCard>, AppError> {
+    Ok(Json((*state.agent_card).clone()))
+}
+
+/// Handle health check requests
+async fn handle_health() -> &'static str {
+    "OK"
+}
+
+/// Application error type
+struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Internal server error: {}", self.0),
+        )
+            .into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}

--- a/samples/rust/a2a-server/src/store.rs
+++ b/samples/rust/a2a-server/src/store.rs
@@ -1,0 +1,86 @@
+use a2a_core::types::{Message, Task};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Trait for task storage
+#[async_trait]
+pub trait TaskStore: Send + Sync {
+    /// Store a task
+    async fn store_task(&self, task: Task) -> anyhow::Result<()>;
+
+    /// Get a task by ID
+    async fn get_task(&self, id: &str) -> anyhow::Result<Option<Task>>;
+
+    /// Update a task
+    async fn update_task(&self, task: Task) -> anyhow::Result<()>;
+
+    /// Delete a task
+    async fn delete_task(&self, id: &str) -> anyhow::Result<()>;
+
+    /// Store a message in the task history
+    async fn store_message(&self, task_id: &str, message: Message) -> anyhow::Result<()>;
+
+    /// Get message history for a task
+    async fn get_history(&self, task_id: &str) -> anyhow::Result<Vec<Message>>;
+}
+
+/// In-memory implementation of TaskStore
+#[derive(Default)]
+pub struct InMemoryTaskStore {
+    tasks: Arc<RwLock<HashMap<String, Task>>>,
+    history: Arc<RwLock<HashMap<String, Vec<Message>>>>,
+}
+
+impl InMemoryTaskStore {
+    pub fn new() -> Self {
+        Self {
+            tasks: Arc::new(RwLock::new(HashMap::new())),
+            history: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[async_trait]
+impl TaskStore for InMemoryTaskStore {
+    async fn store_task(&self, task: Task) -> anyhow::Result<()> {
+        let mut tasks = self.tasks.write().await;
+        tasks.insert(task.id.clone(), task);
+        Ok(())
+    }
+
+    async fn get_task(&self, id: &str) -> anyhow::Result<Option<Task>> {
+        let tasks = self.tasks.read().await;
+        Ok(tasks.get(id).cloned())
+    }
+
+    async fn update_task(&self, task: Task) -> anyhow::Result<()> {
+        let mut tasks = self.tasks.write().await;
+        tasks.insert(task.id.clone(), task);
+        Ok(())
+    }
+
+    async fn delete_task(&self, id: &str) -> anyhow::Result<()> {
+        let mut tasks = self.tasks.write().await;
+        tasks.remove(id);
+        Ok(())
+    }
+
+    async fn store_message(&self, task_id: &str, message: Message) -> anyhow::Result<()> {
+        let mut history = self.history.write().await;
+        history
+            .entry(task_id.to_string())
+            .or_insert_with(Vec::new)
+            .push(message);
+        Ok(())
+    }
+
+    async fn get_history(&self, task_id: &str) -> anyhow::Result<Vec<Message>> {
+        let history = self.history.read().await;
+        Ok(history.get(task_id).cloned().unwrap_or_default())
+    }
+}
+
+/// Type alias for Arc-wrapped task store
+pub type TaskStoreRef = Arc<dyn TaskStore>;

--- a/samples/rust/agents/hello_world/Cargo.toml
+++ b/samples/rust/agents/hello_world/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hello_world_agent"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "hello_world_agent"
+path = "src/main.rs"
+
+[dependencies]
+a2a-core = { workspace = true }
+a2a-server = { workspace = true }
+
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+async-trait = { workspace = true }

--- a/samples/rust/agents/hello_world/README.md
+++ b/samples/rust/agents/hello_world/README.md
@@ -1,0 +1,355 @@
+# Hello World Agent (Rust) 🦀
+
+A simple Agent2Agent (A2A) protocol agent written in Rust that responds with greetings.
+
+## Overview
+
+This agent demonstrates the basic structure of an A2A agent using the Rust A2A framework. It responds to messages with either a standard "Hello World" or a more enthusiastic "SUPER HELLO WORLD!" depending on the input.
+
+## Features
+
+- **Two greeting modes**:
+  - Standard: Returns "Hello World"
+  - Super: Returns "🌟 SUPER HELLO WORLD! 🌟" (triggered by messages containing "super")
+- **Built with**: `a2a-core` and `a2a-server` Rust libraries
+- **Async runtime**: Powered by Tokio
+- **HTTP server**: Built on Axum
+
+## Prerequisites
+
+- Rust 1.75 or later
+- Cargo (comes with Rust)
+
+## Installation
+
+### 1. Clone the repository:
+
+```bash
+git clone https://github.com/google-a2a/a2a-samples.git
+cd a2a-samples/samples/rust/agents/hello_world
+```
+
+### 2. Build the agent:
+
+```bash
+cargo build
+```
+
+### 3. Run the agent:
+
+```bash
+cargo run
+```
+
+The agent will start on `http://localhost:9999`.
+
+## Usage
+
+### Get Agent Card
+
+Retrieve the agent's metadata:
+
+```bash
+curl http://localhost:9999/agent-card
+```
+
+Response:
+```json
+{
+  "name": "Hello World Agent (Rust)",
+  "description": "A simple hello world agent written in Rust 🦀",
+  "url": "http://localhost:9999",
+  "version": "1.0.0",
+  "capabilities": {
+    "streaming": false,
+    "pushNotifications": false,
+    "stateTransitionHistory": false
+  },
+  "defaultInputModes": ["text"],
+  "defaultOutputModes": ["text"],
+  "skills": [
+    {
+      "id": "hello_world",
+      "name": "Returns hello world",
+      "description": "Just returns hello world",
+      "tags": ["hello world", "greeting"],
+      "examples": ["hi", "hello world", "say hello"]
+    },
+    {
+      "id": "super_hello_world",
+      "name": "Returns a SUPER Hello World",
+      "description": "A more enthusiastic greeting with sparkles ✨",
+      "tags": ["hello world", "super", "greeting"],
+      "examples": ["super hi", "give me a super hello", "super hello world"]
+    }
+  ]
+}
+```
+
+### Send a Message
+
+#### Basic greeting:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "id": "task-001",
+      "message": {
+        "role": "user",
+        "parts": [
+          {
+            "type": "text",
+            "text": "hello"
+          }
+        ]
+      }
+    }
+  }'
+```
+
+Response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "id": "task-001",
+    "status": {
+      "state": "completed"
+    },
+    "artifacts": [
+      {
+        "name": "agent message",
+        "parts": [
+          {
+            "type": "text",
+            "text": "Hello World"
+          }
+        ],
+        "lastChunk": true
+      }
+    ]
+  }
+}
+```
+
+#### Super greeting:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "2",
+    "method": "message/send",
+    "params": {
+      "id": "task-002",
+      "message": {
+        "role": "user",
+        "parts": [
+          {
+            "type": "text",
+            "text": "super hi"
+          }
+        ]
+      }
+    }
+  }'
+```
+
+Response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "2",
+  "result": {
+    "id": "task-002",
+    "status": {
+      "state": "completed"
+    },
+    "artifacts": [
+      {
+        "name": "agent message",
+        "parts": [
+          {
+            "type": "text",
+            "text": "🌟 SUPER HELLO WORLD! 🌟"
+          }
+        ],
+        "lastChunk": true
+      }
+    ]
+  }
+}
+```
+
+### Get Task Status
+
+Retrieve the status of a previously sent task:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "3",
+    "method": "tasks/get",
+    "params": {
+      "id": "task-001"
+    }
+  }'
+```
+
+### Cancel a Task
+
+Cancel an ongoing task:
+
+```bash
+curl -X POST http://localhost:9999/ \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "4",
+    "method": "tasks/cancel",
+    "params": {
+      "id": "task-001"
+    }
+  }'
+```
+
+### Health Check
+
+Check if the server is running:
+
+```bash
+curl http://localhost:9999/health
+```
+
+Response: `OK`
+
+## Code Structure
+
+```
+hello_world/
+├── Cargo.toml          # Package configuration
+├── README.md           # This file
+└── src/
+    └── main.rs         # Main agent implementation
+```
+
+### Key Components
+
+**HelloWorldAgent**: Implements the `AgentExecutor` trait with:
+- `execute()`: Processes incoming messages and generates responses
+- `cancel()`: Handles task cancellation (no-op for this simple agent)
+
+**Agent Card**: Defines the agent's metadata, capabilities, and skills
+
+**Server Setup**: Configures the HTTP server with Axum on port 9999
+
+## Configuration
+
+### Change Port
+
+Edit `main.rs` and modify:
+
+```rust
+let server = A2AServer::new(agent_card, executor, task_store)
+    .with_port(8080);  // Change to your desired port
+```
+
+### Change Host
+
+```rust
+let server = A2AServer::new(agent_card, executor, task_store)
+    .with_host("127.0.0.1")  // Change to your desired host
+    .with_port(9999);
+```
+
+### Logging
+
+Set the `RUST_LOG` environment variable:
+
+```bash
+RUST_LOG=debug cargo run
+```
+
+Levels: `error`, `warn`, `info`, `debug`, `trace`
+
+## Development
+
+### Run with logs:
+
+```bash
+RUST_LOG=info cargo run
+```
+
+### Build optimized binary:
+
+```bash
+cargo build --release
+```
+
+Binary location: `target/release/hello_world_agent`
+
+### Format code:
+
+```bash
+cargo fmt
+```
+
+### Run linter:
+
+```bash
+cargo clippy
+```
+
+## Using as a Template
+
+This agent serves as a simple template for building your own A2A agents. Key patterns to follow:
+
+1. **Implement AgentExecutor**: Define your agent logic in the `execute()` method
+2. **Use EventQueue**: Send messages and status updates via the event queue
+3. **Define AgentCard**: Describe your agent's capabilities and skills
+4. **Create Server**: Initialize and run the `A2AServer`
+
+See the main [Rust README](../../README.md) for more advanced examples.
+
+## Troubleshooting
+
+### Port already in use
+
+If port 9999 is already in use, either:
+1. Stop the other process using the port
+2. Change the port in `main.rs` (see Configuration section)
+
+### Build errors
+
+Ensure you have the latest Rust toolchain:
+
+```bash
+rustup update
+```
+
+### Connection refused
+
+Make sure the agent is running and listening on the correct host/port:
+
+```bash
+curl http://localhost:9999/health
+```
+
+## Related Resources
+
+- [Rust A2A Framework Documentation](../../README.md)
+- [A2A Protocol Specification](https://github.com/google-a2a/a2a)
+- [More A2A Samples](https://github.com/google-a2a/a2a-samples)
+
+## License
+
+MIT OR Apache-2.0

--- a/samples/rust/agents/hello_world/src/main.rs
+++ b/samples/rust/agents/hello_world/src/main.rs
@@ -1,0 +1,147 @@
+use a2a_core::types::{AgentCapabilities, AgentCard, AgentSkill, Message, Task};
+use a2a_server::{
+    executor::{AgentExecutor, EventQueue, RequestContext},
+    store::InMemoryTaskStore,
+    A2AServer,
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// Hello World Agent
+///
+/// A simple agent that responds with "Hello World" to any message.
+struct HelloWorldAgent;
+
+#[async_trait]
+impl AgentExecutor for HelloWorldAgent {
+    async fn execute(
+        &self,
+        context: RequestContext,
+        event_queue: EventQueue,
+    ) -> anyhow::Result<()> {
+        tracing::info!("Executing Hello World agent for task: {}", context.task_id);
+
+        // Extract the user's message
+        let user_message = context
+            .message
+            .parts
+            .iter()
+            .find_map(|part| part.text.as_ref())
+            .unwrap_or(&"".to_string())
+            .to_lowercase();
+
+        tracing::info!("User message: {}", user_message);
+
+        // Generate response based on input
+        let response_text = if user_message.contains("super") {
+            "🌟 SUPER HELLO WORLD! 🌟"
+        } else {
+            "Hello World"
+        };
+
+        // Create agent response message
+        let response = Message::agent_text(response_text);
+
+        // Send the message event
+        event_queue.send_message(response).await?;
+
+        // Mark task as completed
+        let completed_task = Task::new(context.task_id).complete();
+        event_queue.send_completed(completed_task).await?;
+
+        tracing::info!("Hello World agent execution completed");
+
+        Ok(())
+    }
+
+    async fn cancel(&self, context: RequestContext) -> anyhow::Result<()> {
+        tracing::warn!("Cancel requested for task: {}", context.task_id);
+        // For this simple agent, we don't have long-running operations to cancel
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_target(false)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(tracing::Level::INFO.into()),
+        )
+        .init();
+
+    tracing::info!("🦀 Starting Hello World A2A Agent");
+
+    // Define agent skills
+    let basic_skill = AgentSkill {
+        id: "hello_world".to_string(),
+        name: "Returns hello world".to_string(),
+        description: Some("Just returns hello world".to_string()),
+        tags: Some(vec!["hello world".to_string(), "greeting".to_string()]),
+        examples: Some(vec![
+            "hi".to_string(),
+            "hello world".to_string(),
+            "say hello".to_string(),
+        ]),
+        input_modes: None,
+        output_modes: None,
+    };
+
+    let super_skill = AgentSkill {
+        id: "super_hello_world".to_string(),
+        name: "Returns a SUPER Hello World".to_string(),
+        description: Some(
+            "A more enthusiastic greeting with sparkles ✨".to_string(),
+        ),
+        tags: Some(vec![
+            "hello world".to_string(),
+            "super".to_string(),
+            "greeting".to_string(),
+        ]),
+        examples: Some(vec![
+            "super hi".to_string(),
+            "give me a super hello".to_string(),
+            "super hello world".to_string(),
+        ]),
+        input_modes: None,
+        output_modes: None,
+    };
+
+    // Create agent card
+    let agent_card = AgentCard {
+        name: "Hello World Agent (Rust)".to_string(),
+        description: Some("A simple hello world agent written in Rust 🦀".to_string()),
+        url: "http://localhost:9999".to_string(),
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: Some(
+            "https://github.com/google-a2a/a2a-samples/tree/main/samples/rust".to_string(),
+        ),
+        capabilities: AgentCapabilities {
+            streaming: Some(false),
+            push_notifications: Some(false),
+            state_transition_history: Some(false),
+        },
+        authentication: None,
+        default_input_modes: Some(vec!["text".to_string()]),
+        default_output_modes: Some(vec!["text".to_string()]),
+        skills: vec![basic_skill, super_skill],
+    };
+
+    // Create the agent executor
+    let executor = Arc::new(HelloWorldAgent);
+
+    // Create the task store
+    let task_store = Arc::new(InMemoryTaskStore::new());
+
+    // Create and run the server
+    let server = A2AServer::new(agent_card, executor, task_store)
+        .with_host("0.0.0.0")
+        .with_port(9999);
+
+    server.run().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Add a comprehensive Rust implementation of the Agent2Agent (A2A) protocol, including a reusable framework and a working example agent.

Components added:
- a2a-core: Core protocol types library (AgentCard, Task, Message, JSON-RPC)
- a2a-server: HTTP server framework built on Axum with AgentExecutor trait
- agents/hello_world: Example agent demonstrating framework usage

Features:
- Trait-based architecture for implementing custom agents
- Async/await support with Tokio
- HTTP server with Axum and Tower
- In-memory task storage with extensible TaskStore trait
- Event-driven agent execution model
- Comprehensive documentation and examples
- Type-safe serialization with serde

The framework enables building A2A agents in Rust with minimal boilerplate and provides a solid foundation for integrating external APIs like Grok SDK.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
