### PR TITLE
feat(cli): add support for inline and file-based structured data input

### DIFF
--- a/samples/python/hosts/cli/__main__.py
+++ b/samples/python/hosts/cli/__main__.py
@@ -196,19 +196,19 @@ async def completeTask(
         json_path = click.prompt(
             'Enter path to *.json file', default='', show_default=False
         )
-        if not json_path.strip():
-            click.echo('No file path provided.')
-            return True, None, None
-        if not os.path.exists(json_path):
-            click.echo('File not found.')
-            return True, None, None
         try:
             with open(json_path, 'r', encoding='utf-8') as f:
                 json_data = json.load(f)
             message.parts.append(Part(root=DataPart(data=json_data)))
             click.echo(f'Loaded DataPart from {json_path}')
-        except Exception as e:
-            click.echo(f'Failed to read JSON: {e}')
+        except FileNotFoundError:
+            click.echo(f'File not found: {json_path}')
+            return True, None, None
+        except json.JSONDecodeError as e:
+            click.echo(f'Invalid JSON in file {json_path}: {e}')
+            return True, None, None
+        except OSError as e:
+            click.echo(f'Error reading file {json_path}: {e}')
             return True, None, None
 
     payload = MessageSendParams(


### PR DESCRIPTION
### Summary

This update updates the CLI by allowing users to attach structured JSON data to a message either inline or via a file path.

### Details

Added a new click.prompt to ask users whether to provide structured data inline or via a file.

### Inline mode:

Prompts the user for raw JSON input.

Validates and loads the JSON before appending it as a DataPart.

Displays clear error messages for invalid JSON.

### File mode:

Prompts for a path to a *.json file.

Verifies file existence and readability.

Loads the file content into a DataPart.

Handles and reports file or JSON read errors gracefully.

Skips data addition cleanly if the user presses Enter (no input).

### Motivation

Previously, structured data could not be provided when constructing messages through the CLI. This change enables both quick inline JSON entry and loading from external files.

### Testing

Verified both inline and file paths accept valid JSON.

Confirmed appropriate error handling for invalid JSON, missing files, and empty inputs.