### PR TITLE
fix(a2a_gui): add missing fastapi and uvicorn dependencies

### DIFF
--- a/samples/python/hosts/a2a_gui/pyproject.toml
+++ b/samples/python/hosts/a2a_gui/pyproject.toml
@@ -13,11 +13,11 @@ dependencies = [
     "httpx-sse>=0.4.0",
     "jwcrypto>=1.5.6",
     "pydantic>=2.10.6",
-    "fastapi>=0.123.4",
-    "Pillow>=10.0.0",
     "pyjwt>=2.10.1",
     "typing-extensions>=4.12.2",
     "uvicorn>=0.34.0",
+    "fastapi>=0.123.4",
+    "Pillow>=10.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
The server failed to start with a "ModuleNotFoundError" because FastAPI and Uvicorn were not listed in the project dependencies.

This commit adds `fastapi` and `uvicorn` to ensure the application starts correctly.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #417  🦕
