### PR TITLE
ci: use linter rules from the repo

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -25,6 +25,7 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOG_LEVEL: WARN
+          LINTER_RULES_PATH: .
           SHELLCHECK_OPTS: -e SC1091 -e 2086
           VALIDATE_ALL_CODEBASE: false
           FILTER_REGEX_EXCLUDE: "^(\\.github/|\\.vscode/).*|CODE_OF_CONDUCT.md|(extensions/agp/).*"


### PR DESCRIPTION
# Description

Follow [super-linter docs](https://github.com/super-linter/super-linter?tab=readme-ov-file#configure-linters) to use repo local configs instead of the [super-linter defaults](https://github.com/super-linter/super-linter/tree/main/TEMPLATES) (see #423 for more details). 

It doesn't require massive changes as linter runs only on touched files, so proper rules are going to be applied subsequently  if/when files are updated.

Fixes #423
