### PR TITLE
Update the version of a2a-sdk version in pyproject.toml

### DIFF
--- a/samples/python/agents/a2a_mcp/pyproject.toml
+++ b/samples/python/agents/a2a_mcp/pyproject.toml
@@ -5,7 +5,7 @@ description = "A2A - MCP Sample"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "a2a-sdk[sql]>=0.3.10",
+    "a2a-sdk[sql]>=0.3.22",
     "click>=8.1.8",
     "fastmcp>=1.0",
     "google-adk>=1.0.0",


### PR DESCRIPTION
The version "0.3.0" is not applicable for "a2a-sdk" anymore. Running the script "samples/python/agents/a2a_mcp/run.sh" will generates the following issues:


```

  × Failed to download `a2a-sdk==0.3.0`
  ├─▶ Failed to fetch:
  │   `https://files.pythonhosted.org/packages/a5/92/16bfbc2ef0ef037c5860ef3b13e482aeb1860b9643bf833ed522c995f639/a2a_sdk-0.3.0-py3-none-any.whl`
  ╰─▶ HTTP status client error (404 Not Found) for url
      (https://files.pythonhosted.org/packages/a5/92/16bfbc2ef0ef037c5860ef3b13e482aeb1860b9643bf833ed522c995f639/a2a_sdk-0.3.0-py3-none-any.whl)
  help: `a2a-sdk` (v0.3.0) was included because `a2a-mcp` (v0.1.0) depends on `a2a-sdk`

```


Updating the version to 0.3.22 could fix the issue. 
