### PR TITLE
chore: Ignore `Ruff` rules `TRY002` and `TRY003`

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -23,7 +23,7 @@ ignore = [
     "D107",   # Missing docstring in __init__ (use class docstring)
     "TD002",  # Missing author in TODOs (often not required)
     "TD003",  # Missing issue link in TODOs (often not required/available)
-    "T201",   # print presence
+    "T201",   # Print presence
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
     "UP007",  # Do not upgrade `Optional[T]` to `T | None` (PEP 604 syntax)
     "E501",   # Line length (handled by Ruff's dynamic line length)


### PR DESCRIPTION
# Description
Updates the `.ruff.toml` configuration to ignore the following Ruff rules:
-   `TRY002`: Create your own exception
-   `TRY003`: Ignore Avoid specifying long messages outside the exception class

Make minor changes to `ignore` descriptions to make them consistent.
 
# Reasoning
Disabling `TRY002` reduces overhead for simple examples where creating custom exception classes might be excessive and distract from the logic which is being demonstrated. 

Disabling `TRY003` allows contributors to provide detailed context within exception messages, improving readability. The default limit of just one word seems too limiting.

Since this repository serves as a collection of examples, I believe we should prioritize readability by relaxing these rules.


Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #<issue_number_goes_here> 🦕
