### PR TITLE
Add PolicyCheck sample: live e-commerce policy analysis agent

### DIFF
--- a/samples/js/src/agents/policycheck/README.md
+++ b/samples/js/src/agents/policycheck/README.md
@@ -1,0 +1,212 @@
+# PolicyCheck — Live A2A Service Agent
+
+A production A2A service agent for e-commerce policy analysis. PolicyCheck helps AI purchasing agents verify sellers before completing transactions on behalf of users.
+
+## Architecture
+
+```
+┌────────────────────┐     JSON-RPC 2.0      ┌────────────────────┐
+│                    │    POST /api/a2a       │                    │
+│  Purchasing Agent  │ ──────────────────────▶│  PolicyCheck A2A   │
+│  (A2A Client)      │                        │  Server            │
+│                    │◀──────────────────────  │                    │
+└────────────────────┘    Task + Artifacts     └────────┬───────────┘
+                                                        │
+                                                        ▼
+                                               ┌────────────────────┐
+                                               │  Policy Analysis   │
+                                               │  Engine            │
+                                               │                    │
+                                               │  • Risk detection  │
+                                               │  • Score (0-100)   │
+                                               │  • Recommendations │
+                                               └────────────────────┘
+```
+
+## Skills
+
+| Skill ID | Name | Description |
+|----------|------|-------------|
+| `comprehensive-policy-analysis` | Comprehensive Policy Analysis | Full analysis of returns, shipping, warranty, and terms |
+| `quick-risk-check` | Quick Risk Check | Auto-discovers and analyzes policies from a store URL |
+| `returns-policy-analysis` | Returns Policy Analysis | Focused return/refund policy analysis |
+| `shipping-policy-analysis` | Shipping Policy Analysis | Focused shipping policy analysis |
+| `warranty-analysis` | Warranty Analysis | Focused warranty coverage analysis |
+| `terms-analysis` | Terms & Conditions Analysis | Legal risk analysis (arbitration, liability, etc.) |
+
+## Usage Examples
+
+### Natural language request
+
+```bash
+curl -X POST https://legaleasy.tools/api/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Quick check on https://www.amazon.com"}]
+      }
+    }
+  }'
+```
+
+### Structured data request
+
+```bash
+curl -X POST https://legaleasy.tools/api/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{
+          "kind": "data",
+          "data": {"seller_url": "https://www.amazon.com", "skill": "quick-risk-check"},
+          "mimeType": "application/json"
+        }]
+      }
+    }
+  }'
+```
+
+### Raw policy text analysis
+
+```bash
+curl -X POST https://legaleasy.tools/api/a2a \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [{
+          "kind": "text",
+          "text": "All sales are final. No refunds. By using this service you agree to binding arbitration and waive your right to class action lawsuits. Liability shall not exceed $100."
+        }]
+      }
+    }
+  }'
+```
+
+## Response Format
+
+The A2A response follows standard JSON-RPC 2.0 with task status and artifacts:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "id": "task_1234567890_abc1234",
+    "status": {
+      "state": "completed",
+      "message": {
+        "role": "agent",
+        "parts": [{"kind": "text", "text": "Risk Level: HIGH\nBuyer Protection Score: 50/100\n..."}]
+      }
+    },
+    "artifacts": [{
+      "artifactId": "artifact_1234567890_def5678",
+      "name": "policy_analysis",
+      "parts": [
+        {
+          "kind": "data",
+          "data": {
+            "riskLevel": "high",
+            "buyerProtectionScore": 50,
+            "recommendation": "review_carefully",
+            "keyFindings": [
+              "Binding arbitration required",
+              "Class action lawsuits waived",
+              "No refunds - all sales are final",
+              "Liability capped at $100"
+            ],
+            "risks": {
+              "arbitration": true,
+              "classActionWaiver": true,
+              "noRefunds": true,
+              "liabilityCap": 100
+            }
+          },
+          "mimeType": "application/json"
+        },
+        {
+          "kind": "text",
+          "text": "Risk Level: HIGH\nBuyer Protection Score: 50/100\nRecommendation: review_carefully"
+        }
+      ]
+    }]
+  }
+}
+```
+
+## Integration Example
+
+Using PolicyCheck in a purchasing agent workflow:
+
+```javascript
+async function checkSellerBeforePurchase(sellerUrl) {
+  const response = await fetch("https://legaleasy.tools/api/a2a", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "message/send",
+      params: {
+        message: {
+          role: "user",
+          parts: [{
+            kind: "data",
+            data: { seller_url: sellerUrl, skill: "quick-risk-check" },
+            mimeType: "application/json"
+          }]
+        }
+      }
+    })
+  });
+
+  const { result } = await response.json();
+  const analysis = result.artifacts[0].parts.find(p => p.kind === "data").data;
+
+  if (analysis.buyerProtectionScore < 60) {
+    console.log(`Warning: ${analysis.riskLevel} risk - ${analysis.recommendation}`);
+    return false; // Do not proceed with purchase
+  }
+  return true; // Safe to proceed
+}
+```
+
+## Multi-Protocol Support
+
+PolicyCheck is available via multiple protocols:
+
+| Protocol | Endpoint | Use Case |
+|----------|----------|----------|
+| **A2A** | `https://legaleasy.tools/api/a2a` | Agent-to-agent communication |
+| **MCP** | `npx -y policycheck-mcp` | Claude Desktop, Claude Code, Cursor |
+| **x402** | `POST https://legaleasy.tools/api/x402/analyze` | Paid analysis via crypto micropayments |
+
+## Links
+
+- **Agent Card:** https://legaleasy.tools/.well-known/agent.json
+- **A2A Endpoint:** https://legaleasy.tools/api/a2a
+- **MCP Package:** https://www.npmjs.com/package/policycheck-mcp
+- **Website:** https://legaleasy.tools
+
+## Running the Test Client
+
+```bash
+node test_client.mjs
+```
+
+No dependencies required — uses native `fetch`.

--- a/samples/js/src/agents/policycheck/test_client.mjs
+++ b/samples/js/src/agents/policycheck/test_client.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+/**
+ * PolicyCheck A2A Test Client
+ *
+ * Demonstrates interacting with a live hosted A2A service agent.
+ * No dependencies required — uses native fetch.
+ *
+ * Usage: node test_client.mjs
+ */
+
+const A2A_ENDPOINT = "https://legaleasy.tools/api/a2a";
+const AGENT_CARD_URL = "https://legaleasy.tools/.well-known/agent.json";
+
+let rpcId = 0;
+
+async function sendA2ARequest(message) {
+  const body = {
+    jsonrpc: "2.0",
+    id: ++rpcId,
+    method: "message/send",
+    params: { message },
+  };
+
+  const res = await fetch(A2A_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+function printResult(label, response) {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(label);
+  console.log("=".repeat(60));
+
+  if (response.error) {
+    console.log("ERROR:", response.error.message);
+    return;
+  }
+
+  const task = response.result;
+  console.log(`Task ID:  ${task.id}`);
+  console.log(`Status:   ${task.status.state}`);
+
+  // Print human-readable summary from status message
+  const statusText = task.status?.message?.parts?.find((p) => p.kind === "text");
+  if (statusText) {
+    console.log(`\nSummary:\n${statusText.text}`);
+  }
+
+  // Print structured data from artifacts
+  const dataArtifact = task.artifacts?.[0]?.parts?.find((p) => p.kind === "data");
+  if (dataArtifact) {
+    const d = dataArtifact.data;
+    console.log(`\nStructured Data:`);
+    console.log(`  Risk Level:            ${d.riskLevel}`);
+    console.log(`  Buyer Protection Score: ${d.buyerProtectionScore}/100`);
+    console.log(`  Recommendation:        ${d.recommendation}`);
+    if (d.policiesFound) {
+      console.log(`  Policies Found:        ${d.policiesFound.join(", ")}`);
+    }
+  }
+}
+
+async function main() {
+  console.log("PolicyCheck A2A Test Client");
+  console.log("Endpoint:", A2A_ENDPOINT);
+
+  // ── Test 1: Discover agent card ──────────────────────────────────────────
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("Test 1: Agent Card Discovery");
+  console.log("=".repeat(60));
+
+  const cardRes = await fetch(AGENT_CARD_URL);
+  if (!cardRes.ok) {
+    console.log(`ERROR: Could not fetch agent card (HTTP ${cardRes.status})`);
+  } else {
+    const card = await cardRes.json();
+    console.log(`Name:         ${card.name}`);
+    console.log(`Description:  ${card.description}`);
+    console.log(`URL:          ${card.url}`);
+    console.log(`Skills:       ${card.skills?.map((s) => s.id).join(", ")}`);
+    console.log(`Version:      ${card.version}`);
+  }
+
+  // ── Test 2: Natural language analysis ────────────────────────────────────
+  const nlResponse = await sendA2ARequest({
+    role: "user",
+    parts: [
+      { kind: "text", text: "Quick check on https://www.amazon.com" },
+    ],
+  });
+  printResult("Test 2: Natural Language Request (Amazon quick check)", nlResponse);
+
+  // ── Test 3: Structured quick risk check ──────────────────────────────────
+  const structuredResponse = await sendA2ARequest({
+    role: "user",
+    parts: [
+      {
+        kind: "data",
+        data: { seller_url: "https://www.amazon.com", skill: "quick-risk-check" },
+        mimeType: "application/json",
+      },
+    ],
+  });
+  printResult("Test 3: Structured Data Request (quick-risk-check)", structuredResponse);
+
+  // ── Test 4: Raw policy text with known risks ─────────────────────────────
+  const riskyText =
+    "All sales are final. No refunds. By using this service you agree to " +
+    "binding arbitration and waive your right to class action lawsuits. " +
+    "Our liability shall not exceed $50. Your account may be terminated " +
+    "at any time without notice. This subscription will auto-renew annually.";
+
+  const textResponse = await sendA2ARequest({
+    role: "user",
+    parts: [{ kind: "text", text: riskyText }],
+  });
+  printResult("Test 4: Raw Policy Text (risky terms)", textResponse);
+
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("All tests complete.");
+  console.log("=".repeat(60));
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds PolicyCheck as a sample agent demonstrating a real-world hosted A2A service agent pattern.

## What's included

- `samples/js/src/agents/policycheck/README.md` - Full documentation with architecture, skills, usage examples, response format, and integration code
- `samples/js/src/agents/policycheck/test_client.mjs` - Runnable Node.js test client (zero dependencies)

## About PolicyCheck

PolicyCheck is a **live, production A2A service agent** for pre-purchase seller policy analysis. It demonstrates the "hosted service agent" pattern where a remote agent provides specialized capabilities to purchasing agents.

**Why this is a useful sample:**

- **Real-world use case** - e-commerce buyer protection, not a toy example
- **Live endpoint** - testable right now, no setup required
- **Multiple input modes** - natural language, structured data, and raw text
- **Standard A2A patterns** - agent card discovery, message/send, task status, artifacts
- **Multi-protocol** - same service available via A2A, MCP, and x402

### Test it now

```bash
node samples/js/src/agents/policycheck/test_client.mjs
```

### Links

- Agent Card: https://legaleasy.tools/.well-known/agent.json
- A2A Endpoint: https://legaleasy.tools/api/a2a
- MCP: https://www.npmjs.com/package/policycheck-mcp
