### PR TITLE
Updated AG2 sample. Switched to Gemini by default

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -102,9 +102,11 @@ Click on the task list to see all the A2A task updates from the remote agents
 
    ```bash
    cd ../../samples/python/agents/ag2/
-   cp ../../../../demo/ui/.env ./
    uv run . --host 0.0.0.0
    ```
+
+   > **Note:** The agent needs a `GOOGLE_API_KEY` or `OPENAI_API_KEY` in its `.env` file.
+   > See [AG2 Setup & Running](../samples/python/agents/ag2/README.md#setup--running) for details.
 
    Then add `localhost:10012` in the Demo UI.
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -98,6 +98,16 @@ Click on the task list to see all the A2A task updates from the remote agents
 
    Answer it's questions in a normal... If you need help converting currency, try adding the LangGraph sample agent too.
 
+   You can also try the **AG2 Python Reviewer** agent:
+
+   ```bash
+   cd ../../samples/python/agents/ag2/
+   cp ../../../../demo/ui/.env ./
+   uv run . --host 0.0.0.0
+   ```
+
+   Then add `localhost:10012` in the Demo UI.
+
    Review the events to see what happened.
 
 ## Build Container Image

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,4 +1,4 @@
-## Demo Web App
+# Demo Web App
 
 This demo application showcases agents talking to other agents over A2A.
 
@@ -88,7 +88,7 @@ Click on the task list to see all the A2A task updates from the remote agents
 
    Back in the demo UI you can go to the _Remote Agents_ tab and add this agent's address:
 
-   ```
+   ```text
    localhost:10002
    ```
 

--- a/samples/python/agents/ag2/Containerfile
+++ b/samples/python/agents/ag2/Containerfile
@@ -8,7 +8,7 @@ COPY ../.. /opt/app-root
 USER root
 
 RUN dnf -y update && dnf install -y gcc gcc-c++ && dnf clean all \
- && pip install uv
+ && pip install --no-cache-dir uv
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
@@ -22,4 +22,4 @@ EXPOSE 10012
 
 USER 1001
 
-CMD uv run . --host 0.0.0.0
+CMD ["uv", "run", ".", "--host", "0.0.0.0"]

--- a/samples/python/agents/ag2/Containerfile
+++ b/samples/python/agents/ag2/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-312:latest
+FROM registry.access.redhat.com/ubi8/python-312:1
 
 WORKDIR /opt/app-root/agents/ag2
 
@@ -7,7 +7,7 @@ COPY ../.. /opt/app-root
 
 USER root
 
-RUN dnf -y update && dnf install -y gcc gcc-c++ && dnf clean all \
+RUN dnf -y update && dnf install -y gcc-8 gcc-c++-8 && dnf clean all \
  && pip install --no-cache-dir uv==0.6.6
 
 ENV UV_COMPILE_BYTECODE=1 \

--- a/samples/python/agents/ag2/Containerfile
+++ b/samples/python/agents/ag2/Containerfile
@@ -7,14 +7,11 @@ COPY ../.. /opt/app-root
 
 USER root
 
-RUN dnf -y update && dnf install -y gcc gcc-c++ \
+RUN dnf -y update && dnf install -y gcc gcc-c++ && dnf clean all \
  && pip install uv
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy
-
-RUN --mount=type=cache,target=/.cache/uv \
-    uv sync --frozen --no-install-project --no-dev
 
 RUN --mount=type=cache,target=/.cache/uv \
     uv sync --frozen --no-dev

--- a/samples/python/agents/ag2/Containerfile
+++ b/samples/python/agents/ag2/Containerfile
@@ -1,0 +1,28 @@
+FROM registry.access.redhat.com/ubi8/python-312
+
+WORKDIR /opt/app-root/agents/ag2
+
+# Copy Python Project Files (Container context must be the `python` directory)
+COPY ../.. /opt/app-root
+
+USER root
+
+RUN dnf -y update && dnf install -y gcc gcc-c++ \
+ && pip install uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+RUN --mount=type=cache,target=/.cache/uv \
+    uv sync --frozen --no-install-project --no-dev
+
+RUN --mount=type=cache,target=/.cache/uv \
+    uv sync --frozen --no-dev
+
+RUN chgrp -R root /opt/app-root/ && chmod -R g+rwx /opt/app-root/
+
+EXPOSE 10012
+
+USER 1001
+
+CMD uv run . --host 0.0.0.0

--- a/samples/python/agents/ag2/Containerfile
+++ b/samples/python/agents/ag2/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/python-312
+FROM registry.access.redhat.com/ubi8/python-312:latest
 
 WORKDIR /opt/app-root/agents/ag2
 
@@ -8,7 +8,7 @@ COPY ../.. /opt/app-root
 USER root
 
 RUN dnf -y update && dnf install -y gcc gcc-c++ && dnf clean all \
- && pip install --no-cache-dir uv
+ && pip install --no-cache-dir uv==0.6.6
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy

--- a/samples/python/agents/ag2/README.md
+++ b/samples/python/agents/ag2/README.md
@@ -47,7 +47,9 @@ Here we have a simple demo that shows how to use the A2A protocol to communicate
 
 - Python 3.12 or higher
 - UV package manager
-- OpenAI API Key (for default configuration)
+- One of the following API keys:
+    - **Google AI Studio** (`GOOGLE_API_KEY`) for Gemini (default)
+    - **OpenAI** (`OPENAI_API_KEY`) for GPT
 
 ## Setup & Running
 
@@ -57,7 +59,15 @@ Here we have a simple demo that shows how to use the A2A protocol to communicate
     cd samples/python/agents/ag2
     ```
 
-2. Create an environment file with your API key (uses `openai gpt-4o`):
+2. Create an environment file with your API key:
+
+    **Option A: Google Gemini (default)**
+
+    ```bash
+    echo "GOOGLE_API_KEY=your_api_key_here" > .env
+    ```
+
+    **Option B: OpenAI**
 
     ```bash
     echo "OPENAI_API_KEY=your_api_key_here" > .env
@@ -70,7 +80,7 @@ Here we have a simple demo that shows how to use the A2A protocol to communicate
 
 4. Run the remote agent:
     ```bash
-    uv run a2a_python_reviewer.py
+    uv run .
     ```
 
 5. In a new terminal, start an A2AClient interface to interact with the remote (ag2) agent. You can use one of the following clients:
@@ -86,6 +96,41 @@ Here we have a simple demo that shows how to use the A2A protocol to communicate
         ```bash
         uv run fastapi_codegen_a2a_client.py
         ```
+
+## Using with the Demo UI
+
+You can also use this agent with the [Demo Web App](/demo/README.md). Start the agent server with:
+
+```bash
+uv run . --host 0.0.0.0
+```
+
+Then add `localhost:10012` as a remote agent in the Demo UI.
+
+## Build Container Image
+
+Agent can also be built using a container file.
+
+1. Navigate to the `samples/python` directory:
+
+    ```bash
+    cd samples/python
+    ```
+
+2. Build the container file
+
+    ```bash
+    podman build -f agents/ag2/Containerfile . -t ag2-a2a
+    ```
+
+> [!Tip]
+> Podman is a drop-in replacement for `docker` which can also be used in these commands.
+
+3. Run your container
+
+    ```bash
+    podman run -p 10012:10012 -e GOOGLE_API_KEY=your_key ag2-a2a
+    ```
 
 ## Learn More
 

--- a/samples/python/agents/ag2/README.md
+++ b/samples/python/agents/ag2/README.md
@@ -48,8 +48,8 @@ Here we have a simple demo that shows how to use the A2A protocol to communicate
 - Python 3.12 or higher
 - UV package manager
 - One of the following API keys:
-    - **Google AI Studio** (`GOOGLE_API_KEY`) for Gemini (default)
-    - **OpenAI** (`OPENAI_API_KEY`) for GPT
+  - **Google AI Studio** (`GOOGLE_API_KEY`) for Gemini (default)
+  - **OpenAI** (`OPENAI_API_KEY`) for GPT
 
 ## Setup & Running
 

--- a/samples/python/agents/ag2/README.md
+++ b/samples/python/agents/ag2/README.md
@@ -129,7 +129,7 @@ Agent can also be built using a container file.
 3. Run your container
 
     ```bash
-    podman run -p 10012:10012 -e GOOGLE_API_KEY=your_key ag2-a2a
+    podman run -p 10012:10012 -e GOOGLE_API_KEY=your_api_key_here ag2-a2a
     ```
 
 ## Learn More

--- a/samples/python/agents/ag2/__main__.py
+++ b/samples/python/agents/ag2/__main__.py
@@ -1,0 +1,19 @@
+"""Entry point for the AG2 A2A Python Reviewer agent."""
+
+import click
+import uvicorn
+
+from a2a_python_reviewer import build_server
+
+
+@click.command()
+@click.option('--host', default='localhost', help='Host to bind to.')
+@click.option('--port', default=10012, help='Port to bind to.')
+def main(host: str, port: int) -> None:
+    """Run the AG2 A2A Python Reviewer agent."""
+    server = build_server(host, port)
+    uvicorn.run(server, host=host, port=port)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/python/agents/ag2/a2a_python_reviewer.py
+++ b/samples/python/agents/ag2/a2a_python_reviewer.py
@@ -1,20 +1,16 @@
-import os
+"""AG2 Python Reviewer agent exposed via A2A protocol."""
+
 import tempfile
 
 from typing import Annotated
 
-from autogen import ConversableAgent, LLMConfig
+from autogen import ConversableAgent
 from autogen.a2a import A2aAgentServer
+from config import get_llm_config
 from mypy import api
 
 
-# create regular AG2 agent
-config = LLMConfig(
-    {
-        'model': 'gpt-4o-mini',
-        'api_key': os.getenv('OPENAI_API_KEY'),
-    }
-)
+config = get_llm_config()
 
 reviewer_agent = ConversableAgent(
     name='ReviewerAgent',
@@ -29,7 +25,6 @@ reviewer_agent = ConversableAgent(
 )
 
 
-# Add mypy tool to validate the code
 @reviewer_agent.register_for_llm(
     name='mypy-checker',
     description='Check the code with mypy tool',
@@ -40,19 +35,19 @@ def review_code_with_mypy(
         'Raw code content to review. Code should be formatted as single file.',
     ],
 ) -> str:
+    """Run mypy on the provided code and return results."""
     with tempfile.NamedTemporaryFile('w', suffix='.py') as tmp:
         tmp.write(code)
+        tmp.flush()
         stdout, stderr, exit_status = api.run([tmp.name])
     if exit_status != 0:
         return stderr
     return stdout or 'No issues found.'
 
 
-# wrap agent to A2A server
-server = A2aAgentServer(reviewer_agent).build()
-
-if __name__ == '__main__':
-    # run server as regular ASGI application
-    import uvicorn
-
-    uvicorn.run(server, host='0.0.0.0', port=8000)
+def build_server(host: str = 'localhost', port: int = 10012) -> object:
+    """Build A2A server with correct discovery URL."""
+    return A2aAgentServer(
+        reviewer_agent,
+        url=f'http://{host}:{port}',
+    ).build()

--- a/samples/python/agents/ag2/cli_codegen_a2a_client.py
+++ b/samples/python/agents/ag2/cli_codegen_a2a_client.py
@@ -1,15 +1,13 @@
-import os
+"""CLI client: AG2 codegen agent that sends code to remote reviewer via A2A."""
 
-from autogen import ConversableAgent, LLMConfig
+import asyncio
+
+from autogen import ConversableAgent
 from autogen.a2a import A2aRemoteAgent
+from config import get_llm_config
 
 
-config = LLMConfig(
-    {
-        'model': 'gpt-4o-mini',
-        'api_key': os.getenv('OPENAI_API_KEY'),
-    }
-)
+config = get_llm_config()
 
 codegen_agent = ConversableAgent(
     name='CodeGenAgent',
@@ -20,7 +18,8 @@ codegen_agent = ConversableAgent(
         'You should create a simple scripts based on user demands. '
         'Generate code in a single file. Do not use any other files. '
         'Do not use any external dependencies if it is possible. '
-        'Use [PEP 723](https://peps.python.org/pep-0723/) to specify script dependencies if it is required. '
+        'Use [PEP 723](https://peps.python.org/pep-0723/) to specify script '
+        'dependencies if it is required. '
         'Generate just a code, no other text or comments. '
         'Terminate conversation when reviewer agent has no issues with the code.'
     ),
@@ -29,24 +28,22 @@ codegen_agent = ConversableAgent(
 )
 
 
-# create A2A remote agent
 reviewer_agent = A2aRemoteAgent(
-    url='http://localhost:8000',
+    url='http://localhost:10012',
     name='ReviewerAgent',
 )
 
 
 async def main() -> str:
-    # use A2A agent as regular one
+    """Run the codegen + review loop and return the final code."""
     result = await reviewer_agent.a_initiate_chat(
         codegen_agent,
-        message='Please, generate a simple script, allows to transfer USD to EUR using any external API.',
+        message='Please, generate a simple script, allows to transfer '
+        'USD to EUR using any external API.',
     )
     return result.chat_history[-2]['content']
 
 
 if __name__ == '__main__':
-    import asyncio
-
     code = asyncio.run(main())
     print(code)

--- a/samples/python/agents/ag2/config.py
+++ b/samples/python/agents/ag2/config.py
@@ -29,8 +29,8 @@ def get_llm_config() -> LLMConfig:
         return LLMConfig(
             {
                 'api_type': 'google',
-                # Change to 'gemini-2.0-pro' or another model as needed.
-                'model': 'gemini-2.0-flash',
+                # Change to 'gemini-2.5-flash' or another model as needed.
+                'model': 'gemini-3-flash-preview',
                 'api_key': google_key,
             }
         )

--- a/samples/python/agents/ag2/config.py
+++ b/samples/python/agents/ag2/config.py
@@ -1,0 +1,43 @@
+"""Shared LLM configuration for the AG2 A2A sample."""
+
+import os
+
+from autogen import LLMConfig
+
+
+def get_llm_config() -> LLMConfig:
+    """Build LLM config from environment variables.
+
+    Supports Gemini (default) and OpenAI.
+    Set GOOGLE_API_KEY for Gemini or OPENAI_API_KEY for OpenAI.
+
+    Returns:
+        LLMConfig configured for the detected provider.
+
+    Raises:
+        ValueError: If neither GOOGLE_API_KEY nor OPENAI_API_KEY is set.
+    """
+    google_key = os.getenv('GOOGLE_API_KEY')
+    openai_key = os.getenv('OPENAI_API_KEY')
+    if not google_key and not openai_key:
+        msg = (
+            'Set GOOGLE_API_KEY (for Gemini) or '
+            'OPENAI_API_KEY (for OpenAI) in your environment.'
+        )
+        raise ValueError(msg)
+    if google_key:
+        return LLMConfig(
+            {
+                'api_type': 'google',
+                # Change to 'gemini-2.0-pro' or another model as needed.
+                'model': 'gemini-2.0-flash',
+                'api_key': google_key,
+            }
+        )
+    return LLMConfig(
+        {
+            # Change to 'gpt-4o' or another model as needed.
+            'model': 'gpt-4o-mini',
+            'api_key': openai_key,
+        }
+    )

--- a/samples/python/agents/ag2/fastapi_codegen_a2a_client.py
+++ b/samples/python/agents/ag2/fastapi_codegen_a2a_client.py
@@ -1,15 +1,13 @@
-import os
+"""FastAPI client: AG2 codegen agent that sends code to remote reviewer via A2A."""
 
-from autogen import ConversableAgent, LLMConfig
+import asyncio
+
+from autogen import ConversableAgent
 from autogen.a2a import A2aRemoteAgent
+from config import get_llm_config
 
 
-config = LLMConfig(
-    {
-        'model': 'gpt-4o-mini',
-        'api_key': os.getenv('OPENAI_API_KEY'),
-    }
-)
+config = get_llm_config()
 
 codegen_agent = ConversableAgent(
     name='CodeGenAgent',
@@ -27,24 +25,22 @@ codegen_agent = ConversableAgent(
 )
 
 
-# create A2A remote agent
 reviewer_agent = A2aRemoteAgent(
-    url='http://localhost:8000',
+    url='http://localhost:10012',
     name='ReviewerAgent',
 )
 
 
 async def main() -> str:
-    # use A2A agent as regular one
+    """Run the codegen + review loop and return the final code."""
     result = await reviewer_agent.a_initiate_chat(
         codegen_agent,
-        message='Please, generate a simple FastAPI application that returns a list of users.',
+        message='Please, generate a simple FastAPI application '
+        'that returns a list of users.',
     )
     return result.chat_history[-2]['content']
 
 
 if __name__ == '__main__':
-    import asyncio
-
     code = asyncio.run(main())
     print(code)

--- a/samples/python/agents/ag2/pyproject.toml
+++ b/samples/python/agents/ag2/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "ag2-a2a"
 version = "0.1.0"
-description = "MCP Mypy agent using A2A and AG2"
+description = "AG2 Python Reviewer agent using A2A protocol"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "ag2[mcp,openai,a2a]>=0.10.0",
+    "ag2[mcp,openai,gemini,a2a]>=0.10.0",
     "mypy>=1.10.0",
+    "click>=8.0.0",
+    "uvicorn>=0.34.0",
 ]

--- a/samples/python/uv.lock
+++ b/samples/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [manifest]
@@ -13,7 +13,7 @@ members = [
     "a2a-samples-file-chat",
     "a2a-samples-image-gen",
     "a2a-samples-marvin",
-    "a2a-samples-mcp",
+    "ag2-a2a",
     "airbnb-planner-multiagent",
     "timestamp-ext",
     "traceability-ext",
@@ -238,25 +238,8 @@ requires-dist = [
 ]
 
 [[package]]
-name = "a2a-samples-mcp"
-version = "0.1.0"
-source = { virtual = "agents/ag2" }
-dependencies = [
-    { name = "a2a-sdk" },
-    { name = "ag2", extra = ["mcp", "openai"] },
-    { name = "google-genai" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.0" },
-    { name = "ag2", extras = ["mcp", "openai"], specifier = ">=0.9.6" },
-    { name = "google-genai", specifier = ">=1.26.0" },
-]
-
-[[package]]
 name = "a2a-sdk"
-version = "0.3.2"
+version = "0.3.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -265,9 +248,16 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/43/57b3f7b45cc19dc52fcae2b9b59a8d7acabe933ae48a8fcf261cd6ff75ae/a2a_sdk-0.3.2.tar.gz", hash = "sha256:b18dcee03678ba6d881a20e0bf1312ad34833a81bed9b060813ee254227e69a4", size = 218438, upload-time = "2025-08-20T20:05:34.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/83/3c99b276d09656cce039464509f05bf385e5600d6dc046a131bbcf686930/a2a_sdk-0.3.25.tar.gz", hash = "sha256:afda85bab8d6af0c5d15e82f326c94190f6be8a901ce562d045a338b7127242f", size = 270638, upload-time = "2026-03-10T13:08:46.417Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/b8/37cc4100df87f14dc1cc56ad827d771652e0930585e348bdcde83e7a8d46/a2a_sdk-0.3.2-py3-none-any.whl", hash = "sha256:8ea1cff85d0f6a698884cc4270021463999291ca6d4e742b1d8114df9411ffd4", size = 134313, upload-time = "2025-08-20T20:05:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f9/6a62520b7ecb945188a6e1192275f4732ff9341cd4629bc975a6c146aeab/a2a_sdk-0.3.25-py3-none-any.whl", hash = "sha256:2fce38faea82eb0b6f9f9c2bcf761b0d78612c80ef0e599b50d566db1b2654b5", size = 149609, upload-time = "2026-03-10T13:08:44.7Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 
 [[package]]
@@ -293,13 +283,13 @@ wheels = [
 
 [[package]]
 name = "ag2"
-version = "0.9.9"
+version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "asyncer" },
     { name = "diskcache" },
     { name = "docker" },
+    { name = "fast-depends", extra = ["pydantic"] },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -307,17 +297,47 @@ dependencies = [
     { name = "termcolor" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/8a/688f90773d298eee00b7c8bd22be0d36ef441647e616a0fa167a9ad20508/ag2-0.9.9.tar.gz", hash = "sha256:33200ded8c60a4c181061632ed38f79e34b87197fc49acebb81d9afc29f70439", size = 3361453, upload-time = "2025-08-20T00:37:05.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/fc/cc2fa430a9ae0bb543622606408e8e938a9932de8a18db7e34d41ab03932/ag2-0.11.3.tar.gz", hash = "sha256:f65f2f726b122425a4c8777d62e130405d72b67da817e7a77c6b89caa44fcc12", size = 3816561, upload-time = "2026-03-16T01:16:25.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/ab/694a26575ecfcc422020d91ef9da31d9368c4e963a030b1261b5d2f16633/ag2-0.9.9-py3-none-any.whl", hash = "sha256:833aeb65d657fd2cb2f8686bab9c0c3ae0b8c806c0e76b670756bd3d8d0b21ea", size = 833981, upload-time = "2025-08-20T00:37:03.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c6/0d451a7cdd666509ca8663719eb2548444eb30b8e019424154f19fabb8c2/ag2-0.11.3-py3-none-any.whl", hash = "sha256:904b5c62e663655fff59546f74d83723c072522dfb1cd9c6cba95fffab63a3b5", size = 1076549, upload-time = "2026-03-16T01:16:22.504Z" },
 ]
 
 [package.optional-dependencies]
+a2a = [
+    { name = "a2a-sdk", extra = ["http-server"] },
+]
+gemini = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-aiplatform" },
+    { name = "google-genai" },
+    { name = "jsonschema" },
+    { name = "pillow" },
+]
 mcp = [
     { name = "mcp" },
 ]
 openai = [
     { name = "openai" },
+]
+
+[[package]]
+name = "ag2-a2a"
+version = "0.1.0"
+source = { virtual = "agents/ag2" }
+dependencies = [
+    { name = "ag2", extra = ["a2a", "gemini", "mcp", "openai"] },
+    { name = "click" },
+    { name = "mypy" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "ag2", extras = ["mcp", "openai", "gemini", "a2a"], specifier = ">=0.10.0" },
+    { name = "click", specifier = ">=8.0.0" },
+    { name = "mypy", specifier = ">=1.10.0" },
+    { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 
 [[package]]
@@ -529,18 +549,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/35/51/b01dd77c9a14fb0b312d799fd8c10b145b882535dbaa9ac055a52515b390/asyncclick-8.2.2.2.tar.gz", hash = "sha256:014f6b7bfb1ef34a2215bc36aebd5150d5d2e50668b12eceb749961e32c24660", size = 1258539, upload-time = "2025-08-15T03:00:05.607Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/20/9ac7bd10ae00075a2b7620e9f29b479d8ef677ba3616ce6a2e8efde80f70/asyncclick-8.2.2.2-py3-none-any.whl", hash = "sha256:ee500f57923e2588d624227d80b568546325a758b902a89519913926454187d9", size = 105081, upload-time = "2025-08-15T03:00:03.721Z" },
-]
-
-[[package]]
-name = "asyncer"
-version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
 ]
 
 [[package]]
@@ -1288,6 +1296,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fast-depends"
+version = "3.0.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/6d/787a21ca8043a8fdb737cf28f645e94a46fc30b44a31de54573299156bad/fast_depends-3.0.8.tar.gz", hash = "sha256:896b16f79a512b6ea1df721b0aa1708a192a06f964be6597e01fcf5412559101", size = 18382, upload-time = "2026-03-02T19:54:28.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/1d/e4843e4eeb65f51447b8c22d200d12d8f94f27c97e77bb7162515cc8d61f/fast_depends-3.0.8-py3-none-any.whl", hash = "sha256:4c52c8a3907bca46d43e70e4364d6d016872d9a3aae4bc0c1c85e72e0a6a21c7", size = 25507, upload-time = "2026-03-02T19:54:27.594Z" },
+]
+
+[package.optional-dependencies]
+pydantic = [
+    { name = "pydantic" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.116.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1939,6 +1965,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -1946,6 +1974,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -2769,6 +2799,53 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/9c/b4b0c54d84da4a94b37bd44151e46d5e583c9534c7e02250b961b1b6d8a8/librt-0.8.1.tar.gz", hash = "sha256:be46a14693955b3bd96014ccbdb8339ee8c9346fbe11c1b78901b55125f14c73", size = 177471, upload-time = "2026-02-17T16:13:06.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/f614c8e4eaac7cbf2bbdf9528790b21d89e277ee20d57dc6e559c626105f/librt-0.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7e6bad1cd94f6764e1e21950542f818a09316645337fd5ab9a7acc45d99a8f35", size = 66529, upload-time = "2026-02-17T16:11:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/96/5836544a45100ae411eda07d29e3d99448e5258b6e9c8059deb92945f5c2/librt-0.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cf450f498c30af55551ba4f66b9123b7185362ec8b625a773b3d39aa1a717583", size = 68669, upload-time = "2026-02-17T16:11:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/06/53/f0b992b57af6d5531bf4677d75c44f095f2366a1741fb695ee462ae04b05/librt-0.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:eca45e982fa074090057132e30585a7e8674e9e885d402eae85633e9f449ce6c", size = 199279, upload-time = "2026-02-17T16:11:59.862Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/4848cc16e268d14280d8168aee4f31cea92bbd2b79ce33d3e166f2b4e4fc/librt-0.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c3811485fccfda840861905b8c70bba5ec094e02825598bb9d4ca3936857a04", size = 210288, upload-time = "2026-02-17T16:12:00.954Z" },
+    { url = "https://files.pythonhosted.org/packages/52/05/27fdc2e95de26273d83b96742d8d3b7345f2ea2bdbd2405cc504644f2096/librt-0.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e4af413908f77294605e28cfd98063f54b2c790561383971d2f52d113d9c363", size = 224809, upload-time = "2026-02-17T16:12:02.108Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d0/78200a45ba3240cb042bc597d6f2accba9193a2c57d0356268cbbe2d0925/librt-0.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5212a5bd7fae98dae95710032902edcd2ec4dc994e883294f75c857b83f9aba0", size = 218075, upload-time = "2026-02-17T16:12:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/af/72/a210839fa74c90474897124c064ffca07f8d4b347b6574d309686aae7ca6/librt-0.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e692aa2d1d604e6ca12d35e51fdc36f4cda6345e28e36374579f7ef3611b3012", size = 225486, upload-time = "2026-02-17T16:12:04.725Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c1/a03cc63722339ddbf087485f253493e2b013039f5b707e8e6016141130fa/librt-0.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4be2a5c926b9770c9e08e717f05737a269b9d0ebc5d2f0060f0fe3fe9ce47acb", size = 218219, upload-time = "2026-02-17T16:12:05.828Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/fff6108af0acf941c6f274a946aea0e484bd10cd2dc37610287ce49388c5/librt-0.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fd1a720332ea335ceb544cf0a03f81df92abd4bb887679fd1e460976b0e6214b", size = 218750, upload-time = "2026-02-17T16:12:07.09Z" },
+    { url = "https://files.pythonhosted.org/packages/71/67/5a387bfef30ec1e4b4f30562c8586566faf87e47d696768c19feb49e3646/librt-0.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2af9e01e0ef80d95ae3c720be101227edae5f2fe7e3dc63d8857fadfc5a1d", size = 241624, upload-time = "2026-02-17T16:12:08.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/be/24f8502db11d405232ac1162eb98069ca49c3306c1d75c6ccc61d9af8789/librt-0.8.1-cp313-cp313-win32.whl", hash = "sha256:086a32dbb71336627e78cc1d6ee305a68d038ef7d4c39aaff41ae8c9aa46e91a", size = 54969, upload-time = "2026-02-17T16:12:09.633Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/c9fdf6cb2a529c1a092ce769a12d88c8cca991194dfe641b6af12fa964d2/librt-0.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:e11769a1dbda4da7b00a76cfffa67aa47cfa66921d2724539eee4b9ede780b79", size = 62000, upload-time = "2026-02-17T16:12:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/97/68f80ca3ac4924f250cdfa6e20142a803e5e50fca96ef5148c52ee8c10ea/librt-0.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:924817ab3141aca17893386ee13261f1d100d1ef410d70afe4389f2359fea4f0", size = 52495, upload-time = "2026-02-17T16:12:11.633Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6a/907ef6800f7bca71b525a05f1839b21f708c09043b1c6aa77b6b827b3996/librt-0.8.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6cfa7fe54fd4d1f47130017351a959fe5804bda7a0bc7e07a2cdbc3fdd28d34f", size = 66081, upload-time = "2026-02-17T16:12:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/18/25e991cd5640c9fb0f8d91b18797b29066b792f17bf8493da183bf5caabe/librt-0.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:228c2409c079f8c11fb2e5d7b277077f694cb93443eb760e00b3b83cb8b3176c", size = 68309, upload-time = "2026-02-17T16:12:13.756Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/36/46820d03f058cfb5a9de5940640ba03165ed8aded69e0733c417bb04df34/librt-0.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7aae78ab5e3206181780e56912d1b9bb9f90a7249ce12f0e8bf531d0462dd0fc", size = 196804, upload-time = "2026-02-17T16:12:14.818Z" },
+    { url = "https://files.pythonhosted.org/packages/59/18/5dd0d3b87b8ff9c061849fbdb347758d1f724b9a82241aa908e0ec54ccd0/librt-0.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:172d57ec04346b047ca6af181e1ea4858086c80bdf455f61994c4aa6fc3f866c", size = 206907, upload-time = "2026-02-17T16:12:16.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/96/ef04902aad1424fd7299b62d1890e803e6ab4018c3044dca5922319c4b97/librt-0.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6b1977c4ea97ce5eb7755a78fae68d87e4102e4aaf54985e8b56806849cc06a3", size = 221217, upload-time = "2026-02-17T16:12:17.906Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/7e01f2dda84a8f5d280637a2e5827210a8acca9a567a54507ef1c75b342d/librt-0.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10c42e1f6fd06733ef65ae7bebce2872bcafd8d6e6b0a08fe0a05a23b044fb14", size = 214622, upload-time = "2026-02-17T16:12:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/8c/5b093d08a13946034fed57619742f790faf77058558b14ca36a6e331161e/librt-0.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4c8dfa264b9193c4ee19113c985c95f876fae5e51f731494fc4e0cf594990ba7", size = 221987, upload-time = "2026-02-17T16:12:20.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cc/86b0b3b151d40920ad45a94ce0171dec1aebba8a9d72bb3fa00c73ab25dd/librt-0.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:01170b6729a438f0dedc4a26ed342e3dc4f02d1000b4b19f980e1877f0c297e6", size = 215132, upload-time = "2026-02-17T16:12:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/be/8588164a46edf1e69858d952654e216a9a91174688eeefb9efbb38a9c799/librt-0.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:7b02679a0d783bdae30d443025b94465d8c3dc512f32f5b5031f93f57ac32071", size = 215195, upload-time = "2026-02-17T16:12:23.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f2/0b9279bea735c734d69344ecfe056c1ba211694a72df10f568745c899c76/librt-0.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:190b109bb69592a3401fe1ffdea41a2e73370ace2ffdc4a0e8e2b39cdea81b78", size = 237946, upload-time = "2026-02-17T16:12:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/cc/5f2a34fbc8aeb35314a3641f9956fa9051a947424652fad9882be7a97949/librt-0.8.1-cp314-cp314-win32.whl", hash = "sha256:e70a57ecf89a0f64c24e37f38d3fe217a58169d2fe6ed6d70554964042474023", size = 50689, upload-time = "2026-02-17T16:12:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/cd4d010ab2147339ca2b93e959c3686e964edc6de66ddacc935c325883d7/librt-0.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:7e2f3edca35664499fbb36e4770650c4bd4a08abc1f4458eab9df4ec56389730", size = 57875, upload-time = "2026-02-17T16:12:27.465Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0f/2143cb3c3ca48bd3379dcd11817163ca50781927c4537345d608b5045998/librt-0.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:0d2f82168e55ddefd27c01c654ce52379c0750ddc31ee86b4b266bcf4d65f2a3", size = 48058, upload-time = "2026-02-17T16:12:28.556Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/0e/9b23a87e37baf00311c3efe6b48d6b6c168c29902dfc3f04c338372fd7db/librt-0.8.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2c74a2da57a094bd48d03fa5d196da83d2815678385d2978657499063709abe1", size = 68313, upload-time = "2026-02-17T16:12:29.659Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/859c41e5a4f1c84200a7d2b92f586aa27133c8243b6cac9926f6e54d01b9/librt-0.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a355d99c4c0d8e5b770313b8b247411ed40949ca44e33e46a4789b9293a907ee", size = 70994, upload-time = "2026-02-17T16:12:31.516Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/28/10605366ee599ed34223ac2bf66404c6fb59399f47108215d16d5ad751a8/librt-0.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2eb345e8b33fb748227409c9f1233d4df354d6e54091f0e8fc53acdb2ffedeb7", size = 220770, upload-time = "2026-02-17T16:12:33.294Z" },
+    { url = "https://files.pythonhosted.org/packages/af/8d/16ed8fd452dafae9c48d17a6bc1ee3e818fd40ef718d149a8eff2c9f4ea2/librt-0.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9be2f15e53ce4e83cc08adc29b26fb5978db62ef2a366fbdf716c8a6c8901040", size = 235409, upload-time = "2026-02-17T16:12:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1b/7bdf3e49349c134b25db816e4a3db6b94a47ac69d7d46b1e682c2c4949be/librt-0.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:785ae29c1f5c6e7c2cde2c7c0e148147f4503da3abc5d44d482068da5322fd9e", size = 246473, upload-time = "2026-02-17T16:12:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/91fab8e4fd2a24930a17188c7af5380eb27b203d72101c9cc000dbdfd95a/librt-0.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d3a7da44baf692f0c6aeb5b2a09c5e6fc7a703bca9ffa337ddd2e2da53f7732", size = 238866, upload-time = "2026-02-17T16:12:37.849Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e0/c45a098843fc7c07e18a7f8a24ca8496aecbf7bdcd54980c6ca1aaa79a8e/librt-0.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5fc48998000cbc39ec0d5311312dda93ecf92b39aaf184c5e817d5d440b29624", size = 250248, upload-time = "2026-02-17T16:12:39.445Z" },
+    { url = "https://files.pythonhosted.org/packages/82/30/07627de23036640c952cce0c1fe78972e77d7d2f8fd54fa5ef4554ff4a56/librt-0.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e96baa6820280077a78244b2e06e416480ed859bbd8e5d641cf5742919d8beb4", size = 240629, upload-time = "2026-02-17T16:12:40.889Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c1/55bfe1ee3542eba055616f9098eaf6eddb966efb0ca0f44eaa4aba327307/librt-0.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:31362dbfe297b23590530007062c32c6f6176f6099646bb2c95ab1b00a57c382", size = 239615, upload-time = "2026-02-17T16:12:42.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/39/191d3d28abc26c9099b19852e6c99f7f6d400b82fa5a4e80291bd3803e19/librt-0.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc3656283d11540ab0ea01978378e73e10002145117055e03722417aeab30994", size = 263001, upload-time = "2026-02-17T16:12:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/eb/7697f60fbe7042ab4e88f4ee6af496b7f222fffb0a4e3593ef1f29f81652/librt-0.8.1-cp314-cp314t-win32.whl", hash = "sha256:738f08021b3142c2918c03692608baed43bc51144c29e35807682f8070ee2a3a", size = 51328, upload-time = "2026-02-17T16:12:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/72/34bf2eb7a15414a23e5e70ecb9440c1d3179f393d9349338a91e2781c0fb/librt-0.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89815a22daf9c51884fb5dbe4f1ef65ee6a146e0b6a8df05f753e2e4a9359bf4", size = 58722, upload-time = "2026-02-17T16:12:46.85Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c8/d148e041732d631fc76036f8b30fae4e77b027a1e95b7a84bb522481a940/librt-0.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:bf512a71a23504ed08103a13c941f763db13fb11177beb3d9244c98c29fb4a61", size = 48755, upload-time = "2026-02-17T16:12:47.943Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.74.9"
 source = { registry = "https://pypi.org/simple" }
@@ -3199,6 +3276,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
     { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/db/4efed9504bc01309ab9c2da7e352cc223569f05478012b5d9ece38fd44d2/mypy-1.19.1.tar.gz", hash = "sha256:19d88bb05303fe63f71dd2c6270daca27cb9401c4ca8255fe50d1d920e0eb9ba", size = 3582404, upload-time = "2025-12-15T05:03:48.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/9f/a6abae693f7a0c697dbb435aac52e958dc8da44e92e08ba88d2e42326176/mypy-1.19.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e3157c7594ff2ef1634ee058aafc56a82db665c9438fd41b390f3bde1ab12250", size = 13201927, upload-time = "2025-12-15T05:02:29.138Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/45c35ccf6e1c65afc23a069f50e2c66f46bd3798cbe0d680c12d12935caa/mypy-1.19.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdb12f69bcc02700c2b47e070238f42cb87f18c0bc1fc4cdb4fb2bc5fd7a3b8b", size = 12206730, upload-time = "2025-12-15T05:03:01.325Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bb/cdcf89678e26b187650512620eec8368fded4cfd99cfcb431e4cdfd19dec/mypy-1.19.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f859fb09d9583a985be9a493d5cfc5515b56b08f7447759a0c5deaf68d80506e", size = 12724581, upload-time = "2025-12-15T05:03:20.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/32/dd260d52babf67bad8e6770f8e1102021877ce0edea106e72df5626bb0ec/mypy-1.19.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9a6538e0415310aad77cb94004ca6482330fece18036b5f360b62c45814c4ef", size = 13616252, upload-time = "2025-12-15T05:02:49.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/d0/5e60a9d2e3bd48432ae2b454b7ef2b62a960ab51292b1eda2a95edd78198/mypy-1.19.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:da4869fc5e7f62a88f3fe0b5c919d1d9f7ea3cef92d3689de2823fd27e40aa75", size = 13840848, upload-time = "2025-12-15T05:02:55.95Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/d32051fa65ecf6cc8c6610956473abdc9b4c43301107476ac03559507843/mypy-1.19.1-cp313-cp313-win_amd64.whl", hash = "sha256:016f2246209095e8eda7538944daa1d60e1e8134d98983b9fc1e92c1fc0cb8dd", size = 10135510, upload-time = "2025-12-15T05:02:58.438Z" },
+    { url = "https://files.pythonhosted.org/packages/de/eb/b83e75f4c820c4247a58580ef86fcd35165028f191e7e1ba57128c52782d/mypy-1.19.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06e6170bd5836770e8104c8fdd58e5e725cfeb309f0a6c681a811f557e97eac1", size = 13199744, upload-time = "2025-12-15T05:03:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/52785ab7bfa165f87fcbb61547a93f98bb20e7f82f90f165a1f69bce7b3d/mypy-1.19.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:804bd67b8054a85447c8954215a906d6eff9cabeabe493fb6334b24f4bfff718", size = 12215815, upload-time = "2025-12-15T05:02:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c6/bdd60774a0dbfb05122e3e925f2e9e846c009e479dcec4821dad881f5b52/mypy-1.19.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21761006a7f497cb0d4de3d8ef4ca70532256688b0523eee02baf9eec895e27b", size = 12740047, upload-time = "2025-12-15T05:03:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2a/66ba933fe6c76bd40d1fe916a83f04fed253152f451a877520b3c4a5e41e/mypy-1.19.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:28902ee51f12e0f19e1e16fbe2f8f06b6637f482c459dd393efddd0ec7f82045", size = 13601998, upload-time = "2025-12-15T05:03:13.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
 ]
 
 [[package]]
@@ -3685,6 +3789,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/86/13/459e86c9c67a006651803a3df3d0b08f7708bc5483fdc482582d75562949/partial_json_parser-0.2.1.1.post6.tar.gz", hash = "sha256:43896b68929678224cbbe4884a6a5fe9251ded4b30b8b7d7eb569e5feea93afc", size = 10299, upload-time = "2025-06-23T17:51:45.372Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/40/1f922794af3dc7503f19319a8804b398a161a2cd54183cff8b12225b8d85/partial_json_parser-0.2.1.1.post6-py3-none-any.whl", hash = "sha256:abc332f09b13ef5233384dbfe7128a0e9ea3fa4b8f8be9b37ac1b433c810e99e", size = 10876, upload-time = "2025-06-23T17:51:44.332Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

- Switch to Gemini by default. OpenAI still supported as fallback via `OPENAI_API_KEY`.
- Simplify setup.
- Add Containerfile and demo UI integration.

Fixes https://github.com/a2aproject/a2a-samples/issues/454
