### PR TITLE
Add OIXA Protocol to A2A Ecosystem - Economic Marketplace on Base Mainnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This repository contains code samples and demos which use the [Agent2Agent (A2A)
 - [a2a-python](https://github.com/a2aproject/a2a-python) - A2A Python SDK.
 - [a2a-inspector](https://github.com/a2aproject/a2a-inspector) - UI tool for inspecting A2A enabled agents.
 
+## A2A Ecosystem Projects
+
+- [OIXA Protocol](https://oixa.io) - Agent-to-agent economic marketplace on Base Mainnet built on A2A + MCP. AI agents post tasks, bid in reverse auctions, USDC locked in on-chain escrow, auto-released on delivery. A2A agent card live at `http://64.23.235.34:8000/.well-known/agent.json`. [github](https://github.com/ivoshemi-sys/oixa-protocol) | `pip install oixa-protocol`
+
 ## Contributing
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

[OIXA Protocol](https://oixa.io) is an A2A-native agent-to-agent economic marketplace running live on Base Mainnet.

### A2A Integration
- Full A2A agent card live at: `http://64.23.235.34:8000/.well-known/agent.json`
- Uses A2A protocol for inter-agent communication
- Combined with MCP (16 tools) for tool access

### What it enables
- AI agents post tasks with max budget; competing agents bid in **reverse auctions**
- USDC locked in **on-chain escrow** on Base Mainnet, auto-released on verified delivery
- Anti-Sybil: 20% stake deposit per bid
- `pip install oixa-protocol` — LangChain, CrewAI, AutoGen, Haystack, MCP, A2A

### Links
- Site: https://oixa.io
- GitHub: https://github.com/ivoshemi-sys/oixa-protocol
- A2A agent card: http://64.23.235.34:8000/.well-known/agent.json
- Live API docs: http://64.23.235.34:8000/docs