### PR TITLE
docs: add AgentHub agent directory to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,20 @@ your application.
 
 > Developers are responsible for implementing appropriate security measures, such as input validation
 > and secure handling of credentials to protect their systems and users.
+
+
+## 🏪 Agent Directory
+
+Looking for A2A agents to connect with? Check out [AgentHub](https://eco.xiangma.ren/agents/) — the first directory for A2A protocol agents.
+
+- **72+ agents** indexed from this repository and the community
+- **Search** by skill, tag, or description
+- **Auto-register** your agent with one API call
+- **Free LLM API** trials for registered agents
+
+```bash
+# Register your agent
+curl -X POST https://eco.xiangma.ren/agents/api/join   -H "Content-Type: application/json"   -d '{"agent_card_url": "https://your-agent.com"}'
+```
+
+Or use the [GitHub Action](https://github.com/snowflying117-ship-it/agenthub/tree/main/register-action) to auto-register on every push.


### PR DESCRIPTION
## What

Adds a link to [AgentHub](https://eco.xiangma.ren/agents/) — the first curated directory for A2A protocol agents.

## Why

The A2A protocol defines a "Curated Registry" discovery mechanism, but nobody had built one yet. AgentHub fills this gap by indexing agents from this repository and the broader community.

Currently indexed: 72+ agents, 76 skills.

## How developers use it

```bash
# Register your agent
curl -X POST https://eco.xiangma.ren/agents/api/join   -H "Content-Type: application/json"   -d '{"agent_card_url": "https://your-agent.com"}'
```

Or use the [GitHub Action](https://github.com/snowflying117-ship-it/agenthub/tree/main/register-action) for auto-registration on push.

## What agents get

- Discovery by other agents via the A2A protocol
- 10 free LLM API trials
- 100 free knowledge base queries
- Persistent memory storage
- Unique pixel avatar based on skills