### PR TITLE
docs: add Envoys RFC 9421 message signing example extension

### DIFF
--- a/extensions/envoys-rfc9421-signing/README.md
+++ b/extensions/envoys-rfc9421-signing/README.md
@@ -1,0 +1,38 @@
+# Envoys RFC 9421 Message Signing Extension
+
+This directory contains the specification for the **RFC 9421 Message Signing
+Extension v1** for the Agent2Agent (A2A) protocol.
+
+## Purpose
+
+A2A's transport and session security (API keys, OAuth2, mTLS) authenticate the
+*connection*, and AgentCard signing attests to an agent's *card* at rest. This
+extension adds the missing piece: **per-message proof of origin** — a
+cryptographic guarantee that an individual A2A request genuinely came from the
+agent it claims to be from.
+
+Agents that support this extension sign every A2A request with
+[RFC 9421 HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421) over
+an Ed25519 key. The signature's `keyid` is a resolvable URL that returns the
+signing agent's public key, so a verifier can confirm the sender's identity with
+no shared secret and no central broker — enabling allowlisting, auditing, and
+authorization by **stable agent identity** rather than by an opaque token. The
+signature is carried in the standard HTTP `Signature`, `Signature-Input`, and
+`Content-Digest` headers and does not modify any core A2A data structure.
+
+## Specification
+
+➡️ **[Full Specification (v1)](./v1/spec.md)**
+
+## Reference Implementations
+
+The wire format is the
+[Envoys signature specification](https://envoys.me/specs/signature/v1)
+(RFC 9421 + Ed25519 + resolvable keyids), with Apache-2.0 implementations in:
+
+- **Node:** [`@envoys/sdk`](https://www.npmjs.com/package/@envoys/sdk) (signing +
+  verification) and [`@envoys/a2a`](https://www.npmjs.com/package/@envoys/a2a)
+  (A2A adapter: signed JSON-RPC over RFC 9421)
+- **Python:** [`envoys`](https://pypi.org/project/envoys/) (signing +
+  verification) and [`envoys-mcp`](https://pypi.org/project/envoys-mcp/) (MCP
+  transport integration)

--- a/extensions/envoys-rfc9421-signing/v1/spec.md
+++ b/extensions/envoys-rfc9421-signing/v1/spec.md
@@ -1,0 +1,142 @@
+# A2A Protocol Extension: Envoys RFC 9421 Message Signing (v1)
+
+## Abstract
+
+This extension defines per-message cryptographic proof of origin for A2A
+requests. An agent that supports this extension signs every A2A request with an
+[RFC 9421 HTTP Message Signature](https://www.rfc-editor.org/rfc/rfc9421) over an
+[Ed25519](https://www.rfc-editor.org/rfc/rfc8410) key. The signature's `keyid` is
+a resolvable HTTPS URL that returns the signer's public key, allowing a verifier
+to confirm *which* agent sent each request — with no shared secret and no central
+registry. The normative wire format is the
+[Envoys signature specification](https://envoys.me/specs/signature/v1).
+
+This is a **profile** extension: it constrains how requests are authenticated at
+the HTTP layer and does not add or modify any core A2A data structure.
+
+## Motivation
+
+A2A's transport and session security (`APIKey`, `HTTPAuth`, `OAuth2`, `mTLS`)
+authenticate the connection, and AgentCard signing attests to an agent's card at
+rest. Neither proves that an individual in-flight request originated from the
+claimed agent. This extension fills that gap, enabling a receiver to allowlist,
+audit, and authorize by stable agent identity rather than by an opaque bearer
+token.
+
+## Extension URI
+
+The URI of this extension is
+`https://github.com/a2aproject/a2a-samples/extensions/envoys-rfc9421-signing/v1`.
+
+This is the only URI accepted for this extension.
+
+## Agent Declaration
+
+An agent that signs — or requires signed — A2A requests **MUST** declare support
+in its `AgentCard` under the `extensions` field of the `AgentCapabilities`
+object:
+
+```json
+{
+  "name": "Signed Agent",
+  "url": "https://agent.example/a2a",
+  "capabilities": {
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/envoys-rfc9421-signing/v1",
+        "required": false
+      }
+    ]
+  }
+}
+```
+
+When `required` is `true`, the agent **MUST** reject unsigned or invalid
+requests.
+
+## Signature Scheme
+
+Requests are signed per [RFC 9421](https://www.rfc-editor.org/rfc/rfc9421) with
+the following profile (full normative detail in the
+[Envoys signature specification](https://envoys.me/specs/signature/v1)):
+
+- **Algorithm:** Ed25519 ([RFC 8410](https://www.rfc-editor.org/rfc/rfc8410)).
+- **Covered components:** `"@method"`, `"@path"`, and `"content-digest"` are
+  always covered. Senders **SHOULD** additionally cover `"@authority"` (the
+  lowercased target host) when the target is known at signing time — this
+  scopes the signature to one receiving service, so it cannot be relayed to a
+  different host within the freshness window.
+- **Signature parameters:** `keyid`, `created`, `nonce`, and an **OPTIONAL**
+  `tag` (RFC 9421 §2.3) disambiguating signing purpose.
+- **Body integrity:** a `Content-Digest` header
+  ([RFC 9530](https://www.rfc-editor.org/rfc/rfc9530); SHA-256, or SHA-512 for
+  bodies of 4096 bytes or more) is always signed.
+- **keyid resolution:** `keyid` is an HTTPS URL that returns the signer's public
+  key, as either an Envoys-native `{ address, public_key }` object or a W3C DID
+  Document (`application/did+json`).
+
+The signature is carried in the standard `Signature`, `Signature-Input`, and
+`Content-Digest` HTTP headers. It applies to every A2A transport with HTTP
+request/response semantics (JSON-RPC and HTTP+JSON/REST).
+
+## Verification
+
+A verifier that has activated this extension **MUST**, for each signed request:
+
+1. Check that the covered components listed in `Signature-Input` include
+   `"@method"` and `"@path"`, and — when the request has a body —
+   `"content-digest"`. A signature omitting a required component **MUST** be
+   rejected even if cryptographically valid: without this check, an attacker
+   can substitute the body together with a matching `Content-Digest` header
+   while the signature still verifies.
+2. Verify the `Content-Digest` matches the received body.
+3. Resolve the `keyid` URL to obtain the signer's Ed25519 public key.
+4. Verify the RFC 9421 signature over the covered components. When
+   `"@authority"` is covered, reconstruct its value from the verifier's own
+   authority (configuration or the `Host` header) — never from a
+   sender-controlled field.
+5. Reject signatures whose `created` timestamp falls outside an acceptable
+   freshness window (replay protection).
+
+A successful verification establishes the sender's cryptographic identity (the
+`keyid` / address). Authorization — deciding whether that identity may perform
+the requested action — is a separate, application-defined step (for example, an
+allowlist).
+
+## Extension Activation
+
+Clients activate this extension via the A2A extension activation mechanism — the
+`A2A-Extensions` header for HTTP / JSON-RPC transports, and the equivalent
+metadata for gRPC — as defined in the
+[A2A specification](https://a2a-protocol.org/latest/specification/). Activation
+is independent of the signature itself: an agent **MAY** sign requests whenever
+it holds a key, and a verifier enforces signing for agents that declare this
+extension as `required`.
+
+## Reference Implementations
+
+All reference implementations are Apache-2.0 licensed. The signing libraries
+share one wire format and a common set of reference test vectors:
+
+| Language | Package | Role |
+| --- | --- | --- |
+| Node   | [`@envoys/sdk`](https://www.npmjs.com/package/@envoys/sdk)   | signing + verification |
+| Node   | [`@envoys/a2a`](https://www.npmjs.com/package/@envoys/a2a)   | A2A adapter (signed JSON-RPC over RFC 9421) |
+| Python | [`envoys`](https://pypi.org/project/envoys/)                 | signing + verification |
+| Python | [`envoys-mcp`](https://pypi.org/project/envoys-mcp/)         | MCP Streamable-HTTP integration |
+
+## Security Considerations
+
+- **Identity is not authorization.** A valid signature proves origin, not
+  permission. Pair verification with an allowlist or policy.
+- **Key-resolution trust.** The `keyid` URL **MUST** be fetched over HTTPS.
+  Verifiers **SHOULD** pin the first-seen `(address, public_key)` pair and treat
+  a changed key as a rotation event requiring re-validation.
+- **Replay.** The `created` timestamp and `nonce` bound replay; verifiers
+  **MUST** enforce a freshness window.
+- **Cross-host relay.** A signature that does not cover `"@authority"` is valid
+  for the same method and path on any host within the freshness window, and
+  per-receiver replay caches cannot detect the relay. Covering `"@authority"`
+  closes this; senders **SHOULD** do so whenever the target host is known.
+- **Scope.** A signature attests to "this request body at this moment," not to a
+  whole task or session.

--- a/extensions/envoys-rfc9421-signing/v1/spec.md
+++ b/extensions/envoys-rfc9421-signing/v1/spec.md
@@ -72,8 +72,16 @@ the following profile (full normative detail in the
   ([RFC 9530](https://www.rfc-editor.org/rfc/rfc9530); SHA-256, or SHA-512 for
   bodies of 4096 bytes or more) is always signed.
 - **keyid resolution:** `keyid` is an HTTPS URL that returns the signer's public
-  key, as either an Envoys-native `{ address, public_key }` object or a W3C DID
-  Document (`application/did+json`).
+  key, as either an Envoys-native JSON object (`address`: the agent's
+  identifier string; `public_key`: the Ed25519 public key as a PEM-encoded
+  SubjectPublicKeyInfo per [RFC 8410](https://www.rfc-editor.org/rfc/rfc8410))
+  or a W3C DID Document (`application/did+json`, key carried as an OKP/Ed25519
+  `publicKeyJwk`).
+- **Query strings:** RFC 9421 `@path` excludes the query string. This profile
+  relies on request semantics travelling in the signed body (the JSON-RPC
+  envelope or REST JSON body, covered by `content-digest`); receivers **MUST
+  NOT** derive request semantics from unsigned query parameters. A future
+  revision may add `@query` coverage for transports that require it.
 
 The signature is carried in the standard `Signature`, `Signature-Input`, and
 `Content-Digest` HTTP headers. It applies to every A2A transport with HTTP
@@ -93,10 +101,14 @@ A verifier that has activated this extension **MUST**, for each signed request:
 3. Resolve the `keyid` URL to obtain the signer's Ed25519 public key.
 4. Verify the RFC 9421 signature over the covered components. When
    `"@authority"` is covered, reconstruct its value from the verifier's own
-   authority (configuration or the `Host` header) — never from a
-   sender-controlled field.
+   configured authority — or from the request's `Host` header only after
+   validating it against the set of authorities the server actually serves —
+   never from an unvalidated, sender-controlled field.
 5. Reject signatures whose `created` timestamp falls outside an acceptable
-   freshness window (replay protection).
+   freshness window (the reference implementations use 300 seconds past /
+   30 seconds future), **and** reject any signature already accepted within
+   that window (deduplication by signature value, per the wire
+   specification's replay-protection requirement).
 
 A successful verification establishes the sender's cryptographic identity (the
 `keyid` / address). Authorization — deciding whether that identity may perform
@@ -120,10 +132,10 @@ share one wire format and a common set of reference test vectors:
 
 | Language | Package | Role |
 | --- | --- | --- |
-| Node   | [`@envoys/sdk`](https://www.npmjs.com/package/@envoys/sdk)   | signing + verification |
-| Node   | [`@envoys/a2a`](https://www.npmjs.com/package/@envoys/a2a)   | A2A adapter (signed JSON-RPC over RFC 9421) |
-| Python | [`envoys`](https://pypi.org/project/envoys/)                 | signing + verification |
-| Python | [`envoys-mcp`](https://pypi.org/project/envoys-mcp/)         | MCP Streamable-HTTP integration |
+| Node | [`@envoys/sdk`](https://www.npmjs.com/package/@envoys/sdk) | signing + verification |
+| Node | [`@envoys/a2a`](https://www.npmjs.com/package/@envoys/a2a) | A2A adapter (signed JSON-RPC over RFC 9421) |
+| Python | [`envoys`](https://pypi.org/project/envoys/) | signing + verification |
+| Python | [`envoys-mcp`](https://pypi.org/project/envoys-mcp/) | MCP Streamable-HTTP integration |
 
 ## Security Considerations
 
@@ -132,8 +144,12 @@ share one wire format and a common set of reference test vectors:
 - **Key-resolution trust.** The `keyid` URL **MUST** be fetched over HTTPS.
   Verifiers **SHOULD** pin the first-seen `(address, public_key)` pair and treat
   a changed key as a rotation event requiring re-validation.
-- **Replay.** The `created` timestamp and `nonce` bound replay; verifiers
-  **MUST** enforce a freshness window.
+- **Replay.** A freshness window alone is insufficient — a captured request
+  could be re-presented within it. Verifiers **MUST** enforce a freshness
+  window on `created` (reference: 300 seconds past, 30 seconds future) and
+  **MUST** also reject signatures already accepted within that window
+  (dedup cache keyed by signature value; the `nonce` makes each signature
+  unique even for otherwise-identical requests).
 - **Cross-host relay.** A signature that does not cover `"@authority"` is valid
   for the same method and path on any host within the freshness window, and
   per-receiver replay caches cannot detect the relay. Covering `"@authority"`


### PR DESCRIPTION
## Summary

Adds `extensions/envoys-rfc9421-signing/` — a README plus v1 spec for a **profile extension** that gives A2A requests per-message cryptographic proof of origin, following the structure of the existing `secure-passport` / `timestamp` / `traceability` example extensions (markdown only, no code).

**What it covers:**

- RFC 9421 HTTP Message Signatures over Ed25519, carried in the standard `Signature` / `Signature-Input` / `Content-Digest` headers — no core A2A data structures are modified.
- The signature `keyid` is a resolvable HTTPS URL returning the signer's public key (Envoys-native JSON or W3C DID Document), so a verifier confirms *which agent* sent each request with no shared secret and no central broker.
- Verifier requirements include covered-component enforcement (rejects digest-downgrade attempts), optional `@authority` binding against cross-host relay, and `created` + `nonce` replay bounds.

**Reference implementations** (all Apache-2.0, sharing one wire format and published test vectors): [`@envoys/sdk`](https://www.npmjs.com/package/@envoys/sdk) and [`@envoys/a2a`](https://www.npmjs.com/package/@envoys/a2a) on npm, [`envoys`](https://pypi.org/project/envoys/) and [`envoys-mcp`](https://pypi.org/project/envoys-mcp/) on PyPI. Full normative wire format: https://envoys.me/specs/signature/v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)