### PR TITLE
Add an optional A2A commerce profile sample

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -67,11 +67,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: stable
+          go-version: '1.26.x'
 
       - name: Lint all Go modules
         run: |
-          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2
           status=0
           while IFS= read -r dir; do
             echo "::group::Linting $dir"

--- a/extensions/commerce-profile/README.md
+++ b/extensions/commerce-profile/README.md
@@ -1,0 +1,33 @@
+# Commerce Profile Extension
+
+This directory contains an optional commerce profile for the Agent2Agent
+(A2A) protocol. The profile demonstrates how a paid capability can advertise
+commerce terms without changing A2A message transport.
+
+## Purpose
+
+The Commerce Profile extension shows how an A2A agent can expose:
+
+- A stable Agent Card extension declaration.
+- A descriptor URL for current pricing and settlement terms.
+- A payment proof carried in A2A message metadata.
+- A receipt URL for execution and settlement status.
+
+The sample is intentionally rail-neutral. Payment can happen through x402,
+stablecoin transfer, off-session card billing, invoice, prepaid credits, or
+another provider-specific mechanism.
+
+## Specification
+
+The extension specification is documented here:
+
+[Commerce Profile v1 specification](./v1/spec.md)
+
+## Sample Fixtures
+
+The `v1/samples` directory contains a minimal JSON flow:
+
+- `agent-card.json`: seller Agent Card with the extension declaration.
+- `commerce-descriptor.json`: ACP-style terms for one paid capability.
+- `task-request.json`: A2A `message/send` request with mock payment proof.
+- `receipt.json`: example receipt/status response after execution.

--- a/extensions/commerce-profile/README.md
+++ b/extensions/commerce-profile/README.md
@@ -4,14 +4,17 @@ This directory contains an optional commerce profile for the Agent2Agent
 (A2A) protocol. The profile demonstrates how a paid capability can advertise
 commerce terms without changing A2A message transport.
 
+The fixtures are offline examples. They do not perform a payment, contact a
+seller, or demonstrate production interoperability with any settlement rail.
+
 ## Purpose
 
 The Commerce Profile extension shows how an A2A agent can expose:
 
 - A stable Agent Card extension declaration.
 - A descriptor URL for current pricing and settlement terms.
-- A payment proof carried in A2A message metadata.
-- A receipt URL for execution and settlement status.
+- A terms-bound payment proof carried in A2A message metadata.
+- A receipt URL that reports execution and settlement status separately.
 
 The sample is intentionally rail-neutral. Payment can happen through x402,
 stablecoin transfer, off-session card billing, invoice, prepaid credits, or
@@ -29,5 +32,11 @@ The `v1/samples` directory contains a minimal JSON flow:
 
 - `agent-card.json`: seller Agent Card with the extension declaration.
 - `commerce-descriptor.json`: ACP-style terms for one paid capability.
-- `task-request.json`: A2A `message/send` request with mock payment proof.
+- `task-request.json`: A2A 1.0 `SendMessage` request with mock payment proof.
 - `receipt.json`: example receipt/status response after execution.
+
+Validate the fixture structure and cross-file bindings with:
+
+```bash
+node --test extensions/commerce-profile/test/fixtures.test.mjs
+```

--- a/extensions/commerce-profile/test/fixtures.test.mjs
+++ b/extensions/commerce-profile/test/fixtures.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const extensionRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    ".."
+);
+const extensionUri =
+    "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1";
+const paymentProofKey = `${extensionUri}/paymentProof`;
+
+async function fixture(name) {
+    const source = await readFile(
+        path.join(extensionRoot, "v1", "samples", name),
+        "utf8"
+    );
+    return JSON.parse(source);
+}
+
+test("commerce fixtures use A2A 1.0 and preserve exact commerce bindings", async () => {
+    const [card, descriptor, request, receipt] = await Promise.all([
+        fixture("agent-card.json"),
+        fixture("commerce-descriptor.json"),
+        fixture("task-request.json"),
+        fixture("receipt.json"),
+    ]);
+
+    assert.equal(Object.hasOwn(card, "url"), false);
+    assert.deepEqual(card.supportedInterfaces, [
+        {
+            url: "https://seller.example.com/a2a",
+            protocolBinding: "JSONRPC",
+            protocolVersion: "1.0",
+        },
+    ]);
+    const extension = card.capabilities.extensions.find(
+        (candidate) => candidate.uri === extensionUri
+    );
+    assert.ok(extension);
+    assert.equal(extension.required, false);
+    assert.equal(extension.params.descriptorUrl.startsWith("https://"), true);
+    assert.equal(
+        extension.params.receiptUrlTemplate.startsWith("https://"),
+        true
+    );
+
+    assert.equal(request.method, "SendMessage");
+    const message = request.params.message;
+    assert.equal(message.role, "ROLE_USER");
+    assert.deepEqual(message.extensions, [extensionUri]);
+    assert.equal(message.parts.length, 1);
+    assert.deepEqual(Object.keys(message.parts[0]), ["text"]);
+
+    const proof = message.metadata[paymentProofKey];
+    assert.ok(proof);
+    assert.equal(proof.serviceId, descriptor.serviceId);
+    assert.equal(proof.termsId, descriptor.termsId);
+    assert.equal(proof.requestId, request.id);
+    assert.equal(proof.messageId, message.messageId);
+    assert.equal(proof.amount, descriptor.pricing.unitAmount);
+    assert.equal(proof.currency, descriptor.pricing.currency);
+    assert.ok(
+        descriptor.paymentProof.acceptedProofTypes.includes(proof.proofType)
+    );
+    assert.ok(
+        descriptor.settlement.some(
+            (method) =>
+                method.method === proof.settlementMethod &&
+                method.proofFormat === proof.proofType
+        )
+    );
+    assert.ok(
+        Date.parse(descriptor.issuedAt) < Date.parse(descriptor.validUntil)
+    );
+
+    assert.equal(receipt.receiptClass, "simulation");
+    assert.equal(receipt.executionStatus, "completed");
+    assert.equal(receipt.serviceId, proof.serviceId);
+    assert.equal(receipt.termsId, proof.termsId);
+    assert.equal(receipt.requestId, proof.requestId);
+    assert.equal(receipt.a2a.messageId, proof.messageId);
+    assert.equal(receipt.amount, proof.amount);
+    assert.equal(receipt.currency, proof.currency);
+    assert.equal(receipt.settlement.method, proof.settlementMethod);
+    assert.equal(receipt.settlement.status, "simulated");
+    assert.equal(receipt.settlement.confirmed, false);
+    assert.notEqual(receipt.settlement.proofReference, proof.proof);
+    assert.equal(
+        receipt.settlement.proofReference,
+        `sha256:${createHash("sha256").update(proof.proof).digest("hex")}`
+    );
+    assert.equal(receipt.usage.inputCharacters, message.parts[0].text.length);
+});

--- a/extensions/commerce-profile/v1/samples/agent-card.json
+++ b/extensions/commerce-profile/v1/samples/agent-card.json
@@ -12,7 +12,7 @@
                 "params": {
                     "descriptorUrl": "https://seller.example.com/.well-known/commerce-profile.json",
                     "supportedSettlement": ["x402", "usdc-base", "invoice"],
-                    "receiptUrl": "https://seller.example.com/receipts/{receiptId}"
+                    "receiptUrlTemplate": "https://seller.example.com/receipts/{receiptId}"
                 }
             }
         ]

--- a/extensions/commerce-profile/v1/samples/agent-card.json
+++ b/extensions/commerce-profile/v1/samples/agent-card.json
@@ -1,0 +1,31 @@
+{
+    "name": "Paid Translation Agent",
+    "description": "Translates short business text after payment proof is provided.",
+    "url": "https://seller.example.com/a2a",
+    "version": "0.1.0",
+    "capabilities": {
+        "streaming": false,
+        "extendedAgentCard": false,
+        "extensions": [
+            {
+                "uri": "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1",
+                "params": {
+                    "descriptorUrl": "https://seller.example.com/.well-known/commerce-profile.json",
+                    "supportedSettlement": ["x402", "usdc-base", "invoice"],
+                    "receiptUrl": "https://seller.example.com/receipts/{receiptId}"
+                }
+            }
+        ]
+    },
+    "defaultInputModes": ["text", "text/plain"],
+    "defaultOutputModes": ["text", "text/plain"],
+    "skills": [
+        {
+            "id": "translate_text",
+            "name": "Translate Text",
+            "description": "Translates up to 500 characters into the requested language.",
+            "tags": ["translation", "commerce-profile"],
+            "examples": ["Translate 'hello' to Spanish"]
+        }
+    ]
+}

--- a/extensions/commerce-profile/v1/samples/agent-card.json
+++ b/extensions/commerce-profile/v1/samples/agent-card.json
@@ -1,14 +1,22 @@
 {
     "name": "Paid Translation Agent",
     "description": "Translates short business text after payment proof is provided.",
-    "url": "https://seller.example.com/a2a",
     "version": "0.1.0",
+    "supportedInterfaces": [
+        {
+            "url": "https://seller.example.com/a2a",
+            "protocolBinding": "JSONRPC",
+            "protocolVersion": "1.0"
+        }
+    ],
     "capabilities": {
         "streaming": false,
         "extendedAgentCard": false,
         "extensions": [
             {
                 "uri": "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1",
+                "description": "Advertises external commerce terms and accepts a bound payment proof.",
+                "required": false,
                 "params": {
                     "descriptorUrl": "https://seller.example.com/.well-known/commerce-profile.json",
                     "supportedSettlement": ["x402", "usdc-base", "invoice"],

--- a/extensions/commerce-profile/v1/samples/commerce-descriptor.json
+++ b/extensions/commerce-profile/v1/samples/commerce-descriptor.json
@@ -1,0 +1,41 @@
+{
+    "protocol": "acp",
+    "protocolVersion": "0.1.0",
+    "serviceId": "paid_translation.v1",
+    "agentCardUrl": "https://seller.example.com/.well-known/agent-card.json",
+    "capability": {
+        "id": "translate_text",
+        "inputModes": ["text/plain"],
+        "outputModes": ["text/plain"],
+        "maxCharacters": 500
+    },
+    "pricing": {
+        "model": "per_invocation",
+        "currency": "USD",
+        "unitAmount": "0.05",
+        "minimumCharge": "0.05"
+    },
+    "settlement": [
+        {
+            "method": "x402",
+            "network": "testnet",
+            "proofFormat": "x402-payment-header"
+        },
+        {
+            "method": "usdc-base",
+            "network": "base",
+            "proofFormat": "transaction-reference"
+        },
+        {
+            "method": "invoice",
+            "proofFormat": "buyer-account-reference"
+        }
+    ],
+    "paymentProof": {
+        "metadataKey": "github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof",
+        "acceptedProofTypes": ["x402", "receipt-ref", "transaction-ref"]
+    },
+    "receipts": {
+        "statusUrlTemplate": "https://seller.example.com/receipts/{receiptId}"
+    }
+}

--- a/extensions/commerce-profile/v1/samples/commerce-descriptor.json
+++ b/extensions/commerce-profile/v1/samples/commerce-descriptor.json
@@ -32,10 +32,14 @@
         }
     ],
     "paymentProof": {
-        "metadataKey": "github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof",
-        "acceptedProofTypes": ["x402", "receipt-ref", "transaction-ref"]
+        "metadataKey": "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof",
+        "acceptedProofTypes": [
+            "x402-payment-header",
+            "transaction-reference",
+            "buyer-account-reference"
+        ]
     },
     "receipts": {
-        "statusUrlTemplate": "https://seller.example.com/receipts/{receiptId}"
+        "receiptUrlTemplate": "https://seller.example.com/receipts/{receiptId}"
     }
 }

--- a/extensions/commerce-profile/v1/samples/commerce-descriptor.json
+++ b/extensions/commerce-profile/v1/samples/commerce-descriptor.json
@@ -2,6 +2,9 @@
     "protocol": "acp",
     "protocolVersion": "0.1.0",
     "serviceId": "paid_translation.v1",
+    "termsId": "terms-demo-001",
+    "issuedAt": "2026-06-12T18:00:00Z",
+    "validUntil": "2026-06-12T18:05:00Z",
     "agentCardUrl": "https://seller.example.com/.well-known/agent-card.json",
     "capability": {
         "id": "translate_text",

--- a/extensions/commerce-profile/v1/samples/receipt.json
+++ b/extensions/commerce-profile/v1/samples/receipt.json
@@ -1,0 +1,25 @@
+{
+    "receiptId": "rcpt-demo-001",
+    "serviceId": "paid_translation.v1",
+    "taskId": "task-demo-001",
+    "contextId": "ctx-demo-001",
+    "status": "completed",
+    "amount": {
+        "currency": "USD",
+        "value": "0.05"
+    },
+    "settlement": {
+        "method": "x402",
+        "proofReference": "mock-x402-proof-token",
+        "authorizedAt": "2026-06-12T18:00:00Z"
+    },
+    "usage": {
+        "inputCharacters": 35,
+        "outputCharacters": 16
+    },
+    "a2a": {
+        "messageId": "msg-commerce-1",
+        "agentCardUrl": "https://seller.example.com/.well-known/agent-card.json"
+    },
+    "completedAt": "2026-06-12T18:00:03Z"
+}

--- a/extensions/commerce-profile/v1/samples/receipt.json
+++ b/extensions/commerce-profile/v1/samples/receipt.json
@@ -4,10 +4,8 @@
     "taskId": "task-demo-001",
     "contextId": "ctx-demo-001",
     "status": "completed",
-    "amount": {
-        "currency": "USD",
-        "value": "0.05"
-    },
+    "amount": "0.05",
+    "currency": "USD",
     "settlement": {
         "method": "x402",
         "proofReference": "mock-x402-proof-token",

--- a/extensions/commerce-profile/v1/samples/receipt.json
+++ b/extensions/commerce-profile/v1/samples/receipt.json
@@ -1,18 +1,23 @@
 {
     "receiptId": "rcpt-demo-001",
     "serviceId": "paid_translation.v1",
+    "termsId": "terms-demo-001",
+    "requestId": "commerce-request-1",
     "taskId": "task-demo-001",
     "contextId": "ctx-demo-001",
-    "status": "completed",
+    "receiptClass": "simulation",
+    "executionStatus": "completed",
     "amount": "0.05",
     "currency": "USD",
     "settlement": {
         "method": "x402",
-        "proofReference": "mock-x402-proof-token",
+        "status": "simulated",
+        "confirmed": false,
+        "proofReference": "sha256:8029e47df604ac5cbf56e2686bbf5884efd80b865ebb39b571c5aa88e71b0b03",
         "authorizedAt": "2026-06-12T18:00:00Z"
     },
     "usage": {
-        "inputCharacters": 35,
+        "inputCharacters": 40,
         "outputCharacters": 16
     },
     "a2a": {

--- a/extensions/commerce-profile/v1/samples/task-request.json
+++ b/extensions/commerce-profile/v1/samples/task-request.json
@@ -14,10 +14,10 @@
             "messageId": "msg-commerce-1",
             "kind": "message",
             "metadata": {
-                "github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof": {
+                "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof": {
                     "serviceId": "paid_translation.v1",
                     "settlementMethod": "x402",
-                    "proofType": "x402",
+                    "proofType": "x402-payment-header",
                     "proof": "mock-x402-proof-token",
                     "amount": "0.05",
                     "currency": "USD",

--- a/extensions/commerce-profile/v1/samples/task-request.json
+++ b/extensions/commerce-profile/v1/samples/task-request.json
@@ -1,0 +1,30 @@
+{
+    "jsonrpc": "2.0",
+    "id": "commerce-request-1",
+    "method": "message/send",
+    "params": {
+        "message": {
+            "role": "user",
+            "parts": [
+                {
+                    "type": "text",
+                    "text": "Translate 'invoice attached' to Spanish."
+                }
+            ],
+            "messageId": "msg-commerce-1",
+            "kind": "message",
+            "metadata": {
+                "github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof": {
+                    "serviceId": "paid_translation.v1",
+                    "settlementMethod": "x402",
+                    "proofType": "x402",
+                    "proof": "mock-x402-proof-token",
+                    "amount": "0.05",
+                    "currency": "USD",
+                    "nonce": "demo-nonce-123",
+                    "receiptCallbackUrl": "https://buyer.example.com/receipts"
+                }
+            }
+        }
+    }
+}

--- a/extensions/commerce-profile/v1/samples/task-request.json
+++ b/extensions/commerce-profile/v1/samples/task-request.json
@@ -1,21 +1,25 @@
 {
     "jsonrpc": "2.0",
     "id": "commerce-request-1",
-    "method": "message/send",
+    "method": "SendMessage",
     "params": {
         "message": {
-            "role": "user",
+            "role": "ROLE_USER",
             "parts": [
                 {
-                    "type": "text",
                     "text": "Translate 'invoice attached' to Spanish."
                 }
             ],
             "messageId": "msg-commerce-1",
-            "kind": "message",
+            "extensions": [
+                "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1"
+            ],
             "metadata": {
                 "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof": {
                     "serviceId": "paid_translation.v1",
+                    "termsId": "terms-demo-001",
+                    "requestId": "commerce-request-1",
+                    "messageId": "msg-commerce-1",
                     "settlementMethod": "x402",
                     "proofType": "x402-payment-header",
                     "proof": "mock-x402-proof-token",

--- a/extensions/commerce-profile/v1/samples/task-request.json
+++ b/extensions/commerce-profile/v1/samples/task-request.json
@@ -25,8 +25,7 @@
                     "proof": "mock-x402-proof-token",
                     "amount": "0.05",
                     "currency": "USD",
-                    "nonce": "demo-nonce-123",
-                    "receiptCallbackUrl": "https://buyer.example.com/receipts"
+                    "nonce": "demo-nonce-123"
                 }
             }
         }

--- a/extensions/commerce-profile/v1/spec.md
+++ b/extensions/commerce-profile/v1/spec.md
@@ -40,7 +40,7 @@ An agent that supports this profile SHOULD declare it in the Agent Card
     "params": {
         "descriptorUrl": "https://seller.example.com/.well-known/commerce-profile.json",
         "supportedSettlement": ["x402", "usdc-base", "invoice"],
-        "receiptUrl": "https://seller.example.com/receipts/{receiptId}"
+        "receiptUrlTemplate": "https://seller.example.com/receipts/{receiptId}"
     }
 }
 ```
@@ -76,18 +76,18 @@ After settlement or authorization happens out of band, the buyer attaches a
 payment proof to the A2A message metadata. The metadata key for this extension
 is:
 
-`github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof`
+`https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof`
 
 The value SHOULD include:
 
-| Field              | Required | Description                                 |
-| ------------------ | -------- | ------------------------------------------- |
-| `serviceId`        | Yes      | Service identifier from the descriptor.     |
-| `settlementMethod` | Yes      | Settlement method used by the buyer.        |
-| `proofType`        | Yes      | Proof type, for example `x402`.             |
-| `proof`            | Yes      | Provider-specific proof token or reference. |
-| `amount`           | Yes      | Amount authorized or paid.                  |
-| `currency`         | Yes      | Settlement currency or unit.                |
+| Field              | Req | Description                                 |
+| ------------------ | --- | ------------------------------------------- |
+| `serviceId`        | Yes | Service identifier from the descriptor.     |
+| `settlementMethod` | Yes | Settlement method used by the buyer.        |
+| `proofType`        | Yes | Proof type, e.g. `x402-payment-header`.     |
+| `proof`            | Yes | Provider-specific proof token or reference. |
+| `amount`           | Yes | Amount authorized or paid.                  |
+| `currency`         | Yes | Settlement currency or unit.                |
 
 Sellers MUST validate the payment proof before executing paid work. Buyers and
 sellers SHOULD bind the proof to the requested `serviceId`, amount, and

--- a/extensions/commerce-profile/v1/spec.md
+++ b/extensions/commerce-profile/v1/spec.md
@@ -1,0 +1,133 @@
+# A2A Commerce Profile Extension (v1)
+
+- **URI:** `https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1`
+- **Type:** Profile Extension / Metadata Extension
+- **Version:** 0.1.0
+
+## Abstract
+
+This extension defines an optional profile for paid A2A capability execution.
+It lets an agent advertise where a buyer can fetch current commerce terms, then
+lets the buyer attach a payment proof to the normal A2A message metadata.
+
+The profile does not replace A2A messaging, discovery, authentication, or task
+state. It only standardizes the points where commerce metadata can be declared,
+attached, and reconciled.
+
+## Goals
+
+- Keep the normal A2A `message/send` flow unchanged.
+- Advertise commerce support through `AgentCapabilities.extensions`.
+- Resolve dynamic pricing and settlement terms from a descriptor URL.
+- Carry payment proof in A2A message metadata.
+- Return a receipt identifier that can be reconciled out of band.
+
+## Non-Goals
+
+- Requiring a specific payment provider, chain, token, or processor.
+- Requiring all A2A agents to support paid execution.
+- Defining marketplace ranking, reputation, or identity resolution.
+- Replacing A2A authentication, authorization, or transport security.
+
+## 1. Agent Card Declaration
+
+An agent that supports this profile SHOULD declare it in the Agent Card
+`capabilities.extensions` array.
+
+```json
+{
+    "uri": "https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1",
+    "params": {
+        "descriptorUrl": "https://seller.example.com/.well-known/commerce-profile.json",
+        "supportedSettlement": ["x402", "usdc-base", "invoice"],
+        "receiptUrl": "https://seller.example.com/receipts/{receiptId}"
+    }
+}
+```
+
+The `descriptorUrl` points to the current commerce descriptor for the service.
+The descriptor MAY use an Agoragentic Commerce Protocol (ACP) shape or another
+provider-specific schema. A buyer MUST treat the descriptor as untrusted input.
+
+## 2. Commerce Descriptor
+
+The commerce descriptor describes the paid capability and current terms. It is
+separate from the Agent Card so that price, settlement availability, and rate
+limits can change without republishing the whole card.
+
+The descriptor SHOULD include:
+
+| Field          | Required | Description                                      |
+| -------------- | -------- | ------------------------------------------------ |
+| `serviceId`    | Yes      | Stable identifier for the paid capability.       |
+| `agentCardUrl` | Yes      | URL of the seller's Agent Card.                  |
+| `capability`   | Yes      | Capability id and compatible input/output modes. |
+| `pricing`      | Yes      | Pricing model, currency, and amount.             |
+| `settlement`   | Yes      | Accepted settlement methods and proof format.    |
+| `receipts`     | Yes      | URL template for receipt/status lookup.          |
+
+The `v1/samples/commerce-descriptor.json` fixture shows one ACP-style
+descriptor. Other descriptor schemas can be used if both buyer and seller agree
+on the contract.
+
+## 3. Payment Proof Metadata
+
+After settlement or authorization happens out of band, the buyer attaches a
+payment proof to the A2A message metadata. The metadata key for this extension
+is:
+
+`github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1/paymentProof`
+
+The value SHOULD include:
+
+| Field              | Required | Description                                 |
+| ------------------ | -------- | ------------------------------------------- |
+| `serviceId`        | Yes      | Service identifier from the descriptor.     |
+| `settlementMethod` | Yes      | Settlement method used by the buyer.        |
+| `proofType`        | Yes      | Proof type, for example `x402`.             |
+| `proof`            | Yes      | Provider-specific proof token or reference. |
+| `amount`           | Yes      | Amount authorized or paid.                  |
+| `currency`         | Yes      | Settlement currency or unit.                |
+
+Sellers MUST validate the payment proof before executing paid work. Buyers and
+sellers SHOULD bind the proof to the requested `serviceId`, amount, and
+request identity to prevent proof replay.
+
+## 4. Execution Flow
+
+1. Buyer fetches or discovers a seller Agent Card.
+2. Buyer reads the Commerce Profile extension params.
+3. Buyer fetches the descriptor URL and evaluates terms.
+4. Buyer completes settlement or authorization out of band.
+5. Buyer sends a normal A2A `message/send` request.
+6. Buyer includes payment proof in message metadata.
+7. Seller validates proof and executes the paid capability.
+8. Seller returns or exposes a receipt identifier.
+9. Buyer queries the receipt URL for reconciliation.
+
+## 5. Receipts
+
+A receipt SHOULD let both parties reconcile task execution with settlement.
+Receipts SHOULD include:
+
+- `receiptId`
+- `serviceId`
+- `taskId` or `contextId`
+- final task status
+- amount and currency
+- settlement method and proof reference
+- timestamps for authorization and completion
+
+Receipts SHOULD NOT expose raw payment credentials, private keys, card details,
+or reusable bearer tokens.
+
+## 6. Security Considerations
+
+Commerce descriptors, Agent Cards, messages, and receipts can all be supplied by
+remote agents. Implementations MUST validate and sanitize all fields before
+using them in prompts, logs, billing systems, or settlement systems.
+
+Payment proof SHOULD be short lived or nonce-bound. Sellers SHOULD reject proofs
+that do not match the descriptor terms, the requested capability, or the
+expected amount. Buyers SHOULD keep local receipt records so they can detect
+missing or inconsistent seller receipts.

--- a/extensions/commerce-profile/v1/spec.md
+++ b/extensions/commerce-profile/v1/spec.md
@@ -3,6 +3,7 @@
 - **URI:** `https://github.com/a2aproject/a2a-samples/extensions/commerce-profile/v1`
 - **Type:** Profile Extension / Metadata Extension
 - **Version:** 0.1.0
+- **A2A version:** 1.0
 
 ## Abstract
 
@@ -14,9 +15,12 @@ The profile does not replace A2A messaging, discovery, authentication, or task
 state. It only standardizes the points where commerce metadata can be declared,
 attached, and reconciled.
 
+The bundled fixtures are illustrative and offline. Their proof and receipt are
+explicitly simulated and provide no evidence of payment or settlement.
+
 ## Goals
 
-- Keep the normal A2A `message/send` flow unchanged.
+- Keep the normal A2A `SendMessage` flow unchanged.
 - Advertise commerce support through `AgentCapabilities.extensions`.
 - Resolve dynamic pricing and settlement terms from a descriptor URL.
 - Carry payment proof in A2A message metadata.
@@ -48,6 +52,8 @@ An agent that supports this profile SHOULD declare it in the Agent Card
 The `descriptorUrl` points to the current commerce descriptor for the service.
 The descriptor MAY use an Agoragentic Commerce Protocol (ACP) shape or another
 provider-specific schema. A buyer MUST treat the descriptor as untrusted input.
+The surrounding Agent Card MUST declare its A2A 1.0 endpoint through
+`supportedInterfaces`; see the sample Agent Card for the complete declaration.
 
 ## 2. Commerce Descriptor
 
@@ -60,6 +66,7 @@ The descriptor SHOULD include:
 | Field          | Required | Description                                      |
 | -------------- | -------- | ------------------------------------------------ |
 | `serviceId`    | Yes      | Stable identifier for the paid capability.       |
+| `termsId`      | Yes      | Stable identifier for this exact terms revision. |
 | `agentCardUrl` | Yes      | URL of the seller's Agent Card.                  |
 | `capability`   | Yes      | Capability id and compatible input/output modes. |
 | `pricing`      | Yes      | Pricing model, currency, and amount.             |
@@ -69,6 +76,9 @@ The descriptor SHOULD include:
 The `v1/samples/commerce-descriptor.json` fixture shows one ACP-style
 descriptor. Other descriptor schemas can be used if both buyer and seller agree
 on the contract.
+
+Terms SHOULD have a bounded validity interval. A proof MUST bind the exact
+`termsId`; sellers MUST reject expired terms or a proof for another revision.
 
 ## 3. Payment Proof Metadata
 
@@ -83,6 +93,9 @@ The value SHOULD include:
 | Field              | Req | Description                                 |
 | ------------------ | --- | ------------------------------------------- |
 | `serviceId`        | Yes | Service identifier from the descriptor.     |
+| `termsId`          | Yes | Exact descriptor terms revision.            |
+| `requestId`        | Yes | JSON-RPC request identifier.                |
+| `messageId`        | Yes | A2A message identifier.                     |
 | `settlementMethod` | Yes | Settlement method used by the buyer.        |
 | `proofType`        | Yes | Proof type, e.g. `x402-payment-header`.     |
 | `proof`            | Yes | Provider-specific proof token or reference. |
@@ -91,7 +104,13 @@ The value SHOULD include:
 
 Sellers MUST validate the payment proof before executing paid work. Buyers and
 sellers SHOULD bind the proof to the requested `serviceId`, amount, and
-request identity to prevent proof replay.
+request and message identities to prevent proof replay. A proof that is valid
+for one request MUST NOT authorize another request.
+
+For JSON-RPC over HTTP, a client opts in with the service parameters
+`A2A-Version: 1.0` and `A2A-Extensions: <extension URI>`. The message also lists
+the extension URI in its `extensions` field. The sample request uses the A2A 1.0
+`SendMessage` method and member-based text part representation.
 
 ## 4. Execution Flow
 
@@ -99,7 +118,7 @@ request identity to prevent proof replay.
 2. Buyer reads the Commerce Profile extension params.
 3. Buyer fetches the descriptor URL and evaluates terms.
 4. Buyer completes settlement or authorization out of band.
-5. Buyer sends a normal A2A `message/send` request.
+5. Buyer sends a normal A2A 1.0 `SendMessage` request.
 6. Buyer includes payment proof in message metadata.
 7. Seller validates proof and executes the paid capability.
 8. Seller returns or exposes a receipt identifier.
@@ -112,14 +131,18 @@ Receipts SHOULD include:
 
 - `receiptId`
 - `serviceId`
+- the exact `termsId` and request identifier
 - `taskId` or `contextId`
-- final task status
+- execution status, separately from settlement status
 - amount and currency
 - settlement method and proof reference
 - timestamps for authorization and completion
 
 Receipts SHOULD NOT expose raw payment credentials, private keys, card details,
-or reusable bearer tokens.
+or reusable bearer tokens. A receipt MAY carry a provider transaction reference
+or a one-way proof digest, but MUST NOT copy a bearer proof from the request.
+Simulated receipts MUST identify themselves and MUST NOT claim confirmed
+settlement.
 
 ## 6. Security Considerations
 
@@ -131,3 +154,8 @@ Payment proof SHOULD be short lived or nonce-bound. Sellers SHOULD reject proofs
 that do not match the descriptor terms, the requested capability, or the
 expected amount. Buyers SHOULD keep local receipt records so they can detect
 missing or inconsistent seller receipts.
+
+Descriptor and receipt URLs are remote input. Clients SHOULD enforce HTTPS,
+redirect, DNS, response-size, and content-type policy before fetching them.
+Implementations SHOULD normalize currency and amount representations before
+comparison and consume replay-protected proofs atomically.


### PR DESCRIPTION
## Summary

Issue #444 identified a gap in A2A's commerce examples: agents could advertise paid work, but the repository had no bounded example showing how terms, request proof, and receipts remain linked. This adds an optional, rail-neutral commerce profile without changing A2A transport.

The refreshed sample now:

- uses the A2A 1.0 Agent Card and `SendMessage` wire shapes;
- binds payment proof to the exact service, terms revision, JSON-RPC request, A2A message, amount, and currency;
- separates execution status from settlement status and labels the bundled receipt as simulated;
- avoids copying bearer proof material into the receipt;
- documents extension negotiation and remote-URL validation requirements; and
- includes a dependency-free fixture test for the cross-file contract.

The fixtures are offline examples. They do not contact a seller, move funds, or claim production interoperability with a settlement rail.

Refs #444.

## Validation

- `node --test extensions/commerce-profile/test/fixtures.test.mjs`
- parsed all four JSON fixtures with PowerShell `ConvertFrom-Json`
- `npx --yes prettier --check "extensions/commerce-profile/**/*.{md,json,mjs}"`
- `npx --yes markdownlint-cli2 "extensions/commerce-profile/**/*.md"`
- `git diff --check`
