### PR TITLE
fix(helloworld): declare protocol version 1.0 in agent card

### DIFF
--- a/samples/python/agents/helloworld/__main__.py
+++ b/samples/python/agents/helloworld/__main__.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
             AgentInterface(
                 protocol_binding='JSONRPC',
                 url='http://127.0.0.1:9999',
+                protocol_version='1.0',
             )
         ],
         # The list of AgentSkill objects that this agent offers


### PR DESCRIPTION
helloworld agent implements A2A Protocol v1.0 but was declaring "protocolVersion": "0.3" in its agent card due to the A2A SDK's backward compatibility default. This mismatch causes confusion because the agent card says v0.3 but the agent rejects v0.3 requests like `message/send`, but accepts v1.0 requests like `SendMessage`. Fix is to explicitly set protocol_version='1.0' in the AgentInterface (to match actual implementation)

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-samples/blob/main/CONTRIBUTING.md).

Fixes #599 🦕
