### PR TITLE
Add Fidacy Trust-Verdict extension sample

### DIFF
--- a/extensions/fidacy-trust-verdict/HOWTORUN.md
+++ b/extensions/fidacy-trust-verdict/HOWTORUN.md
@@ -1,0 +1,14 @@
+# How to run
+
+The reference sample is Python and lives in [`v1/samples/python`](./v1/samples/python).
+
+```bash
+cd v1/samples/python
+pip install -r requirements.txt
+export FIDACY_API_KEY=fky_test_...   # a TEST key from app.fidacy.com -> API Keys (mode: test)
+python main.py
+```
+
+It assesses a payment mandate through Fidacy with the `A2A-Version: 1.0` header, reads the verdict
+from `Task.metadata.fidacy_assessment`, and verifies the signed EdDSA JWS against the public JWKS.
+Expected: `signature valid: True`.

--- a/extensions/fidacy-trust-verdict/README.md
+++ b/extensions/fidacy-trust-verdict/README.md
@@ -1,0 +1,31 @@
+# Fidacy Trust-Verdict Extension
+
+This directory contains the specification and a Python sample implementation for the **Fidacy
+Trust-Verdict Extension v1** for the Agent2Agent (A2A) protocol.
+
+## Purpose
+
+The Trust-Verdict extension lets an A2A agent carry a **signed, independently verifiable trust
+verdict** (`approve` / `review` / `deny`) about whether an agent action, typically a payment , 
+should be trusted. It is the complement to **x402** (settlement) and **AP2** (authorization): it
+fills the neutral risk decision the AP2 `risk_data` slot was reserved for.
+
+* **Neutral & verifiable:** the verdict is a compact EdDSA JWS anyone verifies against a public JWKS, no trust in the issuer required.
+* **No new container:** the verdict rides the existing AP2 `risk_data` field or A2A `Task.metadata`.
+* **Declarable:** an agent advertises it in its Agent Card; clients opt in.
+
+## Specification
+
+➡️ **[Full Specification (v1)](./v1/spec.md)** · Canonical URI: <https://fidacy.com/a2a/extensions/trust-verdict/v1>
+
+## Sample Implementation
+
+A runnable Python example assesses a mandate over A2A and verifies the signed verdict against the
+public JWKS.
+
+➡️ **[Python Sample Usage Guide](./v1/samples/python/README.md)**
+
+## Verifier
+
+Open-source verifier (TypeScript/JS): [`@fidacy/verify`](https://www.npmjs.com/package/@fidacy/verify).
+Python verification uses any EdDSA-capable JOSE library (the sample uses `PyJWT[crypto]`).

--- a/extensions/fidacy-trust-verdict/README.md
+++ b/extensions/fidacy-trust-verdict/README.md
@@ -6,7 +6,7 @@ Trust-Verdict Extension v1** for the Agent2Agent (A2A) protocol.
 ## Purpose
 
 The Trust-Verdict extension lets an A2A agent carry a **signed, independently verifiable trust
-verdict** (`approve` / `review` / `deny`) about whether an agent action, typically a payment, 
+verdict** (`approve` / `review` / `deny`) about whether an agent action, typically a payment,
 should be trusted. It is the complement to **x402** (settlement) and **AP2** (authorization): it
 fills the neutral risk decision the AP2 `risk_data` slot was reserved for.
 

--- a/extensions/fidacy-trust-verdict/README.md
+++ b/extensions/fidacy-trust-verdict/README.md
@@ -6,7 +6,7 @@ Trust-Verdict Extension v1** for the Agent2Agent (A2A) protocol.
 ## Purpose
 
 The Trust-Verdict extension lets an A2A agent carry a **signed, independently verifiable trust
-verdict** (`approve` / `review` / `deny`) about whether an agent action, typically a payment , 
+verdict** (`approve` / `review` / `deny`) about whether an agent action, typically a payment, 
 should be trusted. It is the complement to **x402** (settlement) and **AP2** (authorization): it
 fills the neutral risk decision the AP2 `risk_data` slot was reserved for.
 

--- a/extensions/fidacy-trust-verdict/v1/samples/python/README.md
+++ b/extensions/fidacy-trust-verdict/v1/samples/python/README.md
@@ -1,0 +1,13 @@
+# Fidacy Trust-Verdict (A2A), Python sample
+
+Runs the extension end to end: assess a payment mandate through Fidacy over A2A, then **verify the
+signed verdict yourself** against the public JWKS (no trust in the issuer).
+
+```bash
+pip install -r requirements.txt
+export FIDACY_API_KEY=fky_test_...   # a TEST key from app.fidacy.com -> API Keys (mode: test, sandbox)
+python main.py
+```
+
+Expected output ends with `signature valid: True` and `decisions match: True`. The verdict rode in
+`Task.metadata.fidacy_assessment.risk_payload.jws`; verification used only the public JWKS.

--- a/extensions/fidacy-trust-verdict/v1/samples/python/main.py
+++ b/extensions/fidacy-trust-verdict/v1/samples/python/main.py
@@ -1,76 +1,84 @@
-"""
-Fidacy Trust-Verdict Extension (A2A), Python reference sample.
+"""Fidacy Trust-Verdict Extension (A2A): Python reference sample.
 
-Demonstrates the extension end to end:
-  1. An agent assesses a payment mandate through Fidacy inside an A2A flow
-     (the `A2A-Version` header negotiates A2A).
-  2. Fidacy returns the verdict the A2A way, in `Task.metadata` under
-     `fidacy_assessment`, carrying the signed EdDSA JWS.
-  3. The client VERIFIES that JWS itself against the public JWKS (PyJWT, EdDSA-locked).
-     No trust in the issuer is required.
+Assesses a payment mandate through Fidacy inside an A2A flow, then verifies the
+signed EdDSA verdict against the public JWKS. No trust in the issuer is required.
 
 Run:
     pip install -r requirements.txt
-    export FIDACY_API_KEY=fky_test_...   # a TEST key from app.fidacy.com (sandbox, never billed)
+    export FIDACY_API_KEY=fky_test_...
     python main.py
 """
+
+from __future__ import annotations
 
 import os
 import sys
 import uuid
 
-import requests
 import jwt
+import requests
+
 from jwt import PyJWK
 
-API = os.environ.get("FIDACY_API", "https://api.fidacy.com")
-api_key = os.environ.get("FIDACY_API_KEY")
-if not api_key:
-    sys.exit("Set FIDACY_API_KEY (a fky_test_... key from app.fidacy.com -> API Keys, mode: test).")
 
-# A minimal AP2 payment mandate the agent wants assessed.
-mandate = {
-    "vct": "mandate.payment.1",
-    "transaction_id": uuid.uuid4().hex,
-    "payee": {"id": "merchant_demo", "name": "Demo Store"},
-    "payment_amount": {"amount": 2999, "currency": "EUR"},
-    "payment_instrument": {"id": "pi_demo", "type": "card"},
-}
+def main() -> None:
+    """Assess a mandate over A2A and verify the signed verdict."""
+    api = os.environ.get('FIDACY_API', 'https://api.fidacy.com')
+    api_key = os.environ.get('FIDACY_API_KEY')
+    if not api_key:
+        sys.exit('Set FIDACY_API_KEY (a fky_test_... key from app.fidacy.com).')
 
-# 1+2. Assess inside an A2A flow. The `A2A-Version` header engages A2A; the verdict
-# comes back inside the `a2a` block's Task.metadata.
-resp = requests.post(
-    f"{API}/v1/assess",
-    headers={"x-api-key": api_key, "content-type": "application/json", "A2A-Version": "1.0"},
-    json={"kind": "ap2_payment", "mandate": mandate, "a2a": {"task_id": f"task_{uuid.uuid4().hex[:8]}"}},
-    timeout=20,
-)
-resp.raise_for_status()
-result = resp.json()
+    mandate = {
+        'vct': 'mandate.payment.1',
+        'transaction_id': uuid.uuid4().hex,
+        'payee': {'id': 'merchant_demo', 'name': 'Demo Store'},
+        'payment_amount': {'amount': 2999, 'currency': 'EUR'},
+        'payment_instrument': {'id': 'pi_demo', 'type': 'card'},
+    }
 
-a2a = result.get("a2a", {})
-fidacy_assessment = a2a.get("task_metadata", {}).get("fidacy_assessment", {})
-jws = fidacy_assessment.get("risk_payload", {}).get("jws") or result.get("riskPayloadJws")
-if not jws:
-    sys.exit("JWS not found in the assessment response.")
-print("A2A recommended task state:", a2a.get("recommended_task_state"))
-print("Verdict rides in Task.metadata.fidacy_assessment:", bool(fidacy_assessment))
+    resp = requests.post(
+        f'{api}/v1/assess',
+        headers={'x-api-key': api_key, 'content-type': 'application/json', 'A2A-Version': '1.0'},
+        json={
+            'kind': 'ap2_payment',
+            'mandate': mandate,
+            'a2a': {'task_id': f'task_{uuid.uuid4().hex[:8]}'},
+        },
+        timeout=20,
+    )
+    resp.raise_for_status()
+    result = resp.json()
 
-# 3. Verify the signed verdict yourself. Fetch the public JWKS and check the EdDSA
-# signature; jwt.decode raises if the signature is invalid OR the alg isn't EdDSA.
-jwks = requests.get(f"{API}/.well-known/jwks.json", timeout=15).json()
-kid = jwt.get_unverified_header(jws)["kid"]
-jwk = next((k for k in jwks["keys"] if k["kid"] == kid), None)
-if not jwk:
-    sys.exit(f"Key id '{kid}' not found in the JWKS.")
-public_key = PyJWK.from_dict(jwk).key  # OKP / Ed25519
-claims = jwt.decode(
-    jws,
-    public_key,
-    algorithms=["EdDSA"],
-    options={"verify_aud": False, "verify_exp": False, "verify_iat": False, "verify_nbf": False},
-)
+    a2a = result.get('a2a', {})
+    fidacy_assessment = a2a.get('task_metadata', {}).get('fidacy_assessment', {})
+    jws = fidacy_assessment.get('risk_payload', {}).get('jws') or result.get('riskPayloadJws')
+    if not jws:
+        sys.exit('JWS not found in the assessment response.')
+    print('A2A recommended task state:', a2a.get('recommended_task_state'))
+    print('Verdict rides in Task.metadata.fidacy_assessment:', bool(fidacy_assessment))
 
-print("signature valid: True")
-print("decision (verified):", claims.get("decision"), "score:", claims.get("score"))
-print("decisions match:", claims.get("decision") == result.get("decision"))
+    jwks = requests.get(f'{api}/.well-known/jwks.json', timeout=15).json()
+    kid = jwt.get_unverified_header(jws)['kid']
+    jwk = next((k for k in jwks['keys'] if k['kid'] == kid), None)
+    if not jwk:
+        sys.exit(f"Key id '{kid}' not found in the JWKS.")
+    public_key = PyJWK.from_dict(jwk).key
+    claims = jwt.decode(
+        jws,
+        public_key,
+        algorithms=['EdDSA'],
+        options={
+            'verify_aud': False,
+            'verify_exp': False,
+            'verify_iat': False,
+            'verify_nbf': False,
+        },
+    )
+
+    print('signature valid: True')
+    print('decision (verified):', claims.get('decision'), 'score:', claims.get('score'))
+    print('decisions match:', claims.get('decision') == result.get('decision'))
+
+
+if __name__ == '__main__':
+    main()

--- a/extensions/fidacy-trust-verdict/v1/samples/python/main.py
+++ b/extensions/fidacy-trust-verdict/v1/samples/python/main.py
@@ -50,7 +50,9 @@ result = resp.json()
 
 a2a = result.get("a2a", {})
 fidacy_assessment = a2a.get("task_metadata", {}).get("fidacy_assessment", {})
-jws = fidacy_assessment.get("risk_payload", {}).get("jws") or result["riskPayloadJws"]
+jws = fidacy_assessment.get("risk_payload", {}).get("jws") or result.get("riskPayloadJws")
+if not jws:
+    sys.exit("JWS not found in the assessment response.")
 print("A2A recommended task state:", a2a.get("recommended_task_state"))
 print("Verdict rides in Task.metadata.fidacy_assessment:", bool(fidacy_assessment))
 
@@ -58,7 +60,9 @@ print("Verdict rides in Task.metadata.fidacy_assessment:", bool(fidacy_assessmen
 # signature; jwt.decode raises if the signature is invalid OR the alg isn't EdDSA.
 jwks = requests.get(f"{API}/.well-known/jwks.json", timeout=15).json()
 kid = jwt.get_unverified_header(jws)["kid"]
-jwk = next(k for k in jwks["keys"] if k["kid"] == kid)
+jwk = next((k for k in jwks["keys"] if k["kid"] == kid), None)
+if not jwk:
+    sys.exit(f"Key id '{kid}' not found in the JWKS.")
 public_key = PyJWK.from_dict(jwk).key  # OKP / Ed25519
 claims = jwt.decode(
     jws,
@@ -68,5 +72,5 @@ claims = jwt.decode(
 )
 
 print("signature valid: True")
-print("decision (verified):", claims["decision"], "· score:", claims["score"])
-print("decisions match:", claims["decision"] == result["decision"])
+print("decision (verified):", claims.get("decision"), "score:", claims.get("score"))
+print("decisions match:", claims.get("decision") == result.get("decision"))

--- a/extensions/fidacy-trust-verdict/v1/samples/python/main.py
+++ b/extensions/fidacy-trust-verdict/v1/samples/python/main.py
@@ -1,0 +1,72 @@
+"""
+Fidacy Trust-Verdict Extension (A2A), Python reference sample.
+
+Demonstrates the extension end to end:
+  1. An agent assesses a payment mandate through Fidacy inside an A2A flow
+     (the `A2A-Version` header negotiates A2A).
+  2. Fidacy returns the verdict the A2A way, in `Task.metadata` under
+     `fidacy_assessment`, carrying the signed EdDSA JWS.
+  3. The client VERIFIES that JWS itself against the public JWKS (PyJWT, EdDSA-locked).
+     No trust in the issuer is required.
+
+Run:
+    pip install -r requirements.txt
+    export FIDACY_API_KEY=fky_test_...   # a TEST key from app.fidacy.com (sandbox, never billed)
+    python main.py
+"""
+
+import os
+import sys
+import uuid
+
+import requests
+import jwt
+from jwt import PyJWK
+
+API = os.environ.get("FIDACY_API", "https://api.fidacy.com")
+api_key = os.environ.get("FIDACY_API_KEY")
+if not api_key:
+    sys.exit("Set FIDACY_API_KEY (a fky_test_... key from app.fidacy.com -> API Keys, mode: test).")
+
+# A minimal AP2 payment mandate the agent wants assessed.
+mandate = {
+    "vct": "mandate.payment.1",
+    "transaction_id": uuid.uuid4().hex,
+    "payee": {"id": "merchant_demo", "name": "Demo Store"},
+    "payment_amount": {"amount": 2999, "currency": "EUR"},
+    "payment_instrument": {"id": "pi_demo", "type": "card"},
+}
+
+# 1+2. Assess inside an A2A flow. The `A2A-Version` header engages A2A; the verdict
+# comes back inside the `a2a` block's Task.metadata.
+resp = requests.post(
+    f"{API}/v1/assess",
+    headers={"x-api-key": api_key, "content-type": "application/json", "A2A-Version": "1.0"},
+    json={"kind": "ap2_payment", "mandate": mandate, "a2a": {"task_id": f"task_{uuid.uuid4().hex[:8]}"}},
+    timeout=20,
+)
+resp.raise_for_status()
+result = resp.json()
+
+a2a = result.get("a2a", {})
+fidacy_assessment = a2a.get("task_metadata", {}).get("fidacy_assessment", {})
+jws = fidacy_assessment.get("risk_payload", {}).get("jws") or result["riskPayloadJws"]
+print("A2A recommended task state:", a2a.get("recommended_task_state"))
+print("Verdict rides in Task.metadata.fidacy_assessment:", bool(fidacy_assessment))
+
+# 3. Verify the signed verdict yourself. Fetch the public JWKS and check the EdDSA
+# signature; jwt.decode raises if the signature is invalid OR the alg isn't EdDSA.
+jwks = requests.get(f"{API}/.well-known/jwks.json", timeout=15).json()
+kid = jwt.get_unverified_header(jws)["kid"]
+jwk = next(k for k in jwks["keys"] if k["kid"] == kid)
+public_key = PyJWK.from_dict(jwk).key  # OKP / Ed25519
+claims = jwt.decode(
+    jws,
+    public_key,
+    algorithms=["EdDSA"],
+    options={"verify_aud": False, "verify_exp": False, "verify_iat": False, "verify_nbf": False},
+)
+
+print("signature valid: True")
+print("decision (verified):", claims["decision"], "· score:", claims["score"])
+print("decisions match:", claims["decision"] == result["decision"])

--- a/extensions/fidacy-trust-verdict/v1/samples/python/requirements.txt
+++ b/extensions/fidacy-trust-verdict/v1/samples/python/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+PyJWT[crypto]>=2.8

--- a/extensions/fidacy-trust-verdict/v1/spec.md
+++ b/extensions/fidacy-trust-verdict/v1/spec.md
@@ -1,0 +1,89 @@
+# A2A Protocol Extension: Fidacy Trust-Verdict (v1)
+
+- **URI:** `https://fidacy.com/a2a/extensions/trust-verdict/v1`
+- **Type:** Profile Extension / Data-Only Extension
+- **Version:** 1.0.0
+- **Status:** Third-party (neutral). Not an official A2A extension; declarable and opt-in.
+
+## Abstract
+
+This extension lets an A2A agent carry a **trust verdict**, a signed `approve` / `review` / `deny`
+decision about whether an agent action (typically a payment) should be trusted. The verdict is a
+compact **EdDSA JWS** that any party verifies independently against a public JWKS, so it requires no
+trust in the issuer. It is the complement to **x402** (settlement) and **AP2** (authorization): those
+move and authorize money; this one carries the neutral risk decision the AP2 `risk_data` slot was
+left open for.
+
+Fidacy is the reference issuer; the format is verifiable by anyone with the open-source verifier.
+
+## 1. Agent Card declaration
+
+An agent advertises support in its Agent Card under `capabilities.extensions[]`:
+
+```json
+{
+  "uri": "https://fidacy.com/a2a/extensions/trust-verdict/v1",
+  "description": "Carries a Fidacy trust verdict (approve/review/deny), signed and independently verifiable.",
+  "required": false,
+  "params": {
+    "issuer": "did:web:fidacy.com",
+    "jwks_uri": "https://api.fidacy.com/.well-known/jwks.json",
+    "trust_list_uri": "https://api.fidacy.com/.well-known/fidacy-trust-list.json",
+    "verify_package": "@fidacy/verify"
+  }
+}
+```
+
+## 2. Where the verdict rides
+
+The extension does not invent a new container. The verdict travels in existing fields:
+
+- **AP2 flows (preferred):** inside the Cart/Payment Mandate's `risk_data` field as
+  `{ "fidacy": { "decision", "score", "vc_jws", "signing_key_id", "payload" } }`.
+- **Plain A2A flows:** in `Task.metadata` as `{ "fidacy_assessment": { … } }`, where the signed JWS
+  is at `fidacy_assessment.risk_payload.jws`. The decision also maps to an official A2A Task state:
+
+  | `decision` | recommended Task state    |
+  | ---------- | ------------------------- |
+  | `approve`  | `TASK_STATE_WORKING`      |
+  | `review`   | `TASK_STATE_AUTH_REQUIRED`|
+  | `deny`     | `TASK_STATE_REJECTED`     |
+
+## 3. The signed verdict (source of truth)
+
+The JWS (`vc_jws` / `risk_payload.jws`) is a compact **EdDSA** JWS, `typ: application/vc+jws`, whose
+verified claims are the verdict:
+
+| Claim           | Meaning                                                  |
+| --------------- | -------------------------------------------------------- |
+| `issuer`        | `did:web:fidacy.com#<kid>` (kid = JWKS key id)           |
+| `subject`       | the agent/mandate assessed                               |
+| `decision`      | `approve` \| `review` \| `deny`                          |
+| `score`         | 0-100                                                    |
+| `model_version` | scoring model id                                         |
+| `assessed_at`   | ISO 8601                                                 |
+| `signals`       | opaque advisory signals (not normative)                 |
+
+## 4. Verification (normative)
+
+The convenience fields (`decision`, `score`, …) are **untrusted hints** until the JWS is verified. A
+recipient **MUST**:
+
+1. Read the compact JWS from the container.
+2. Fetch the public JWKS (`jwks_uri`), or confirm the active key via `trust_list_uri`.
+3. Verify the **EdDSA** signature (e.g. `@fidacy/verify`, or any JOSE library pinned to `EdDSA`).
+   `alg: none` and non-EdDSA algorithms **MUST** be rejected.
+4. If valid, act on the claims; if invalid or expired, discard the verdict.
+
+No trust in the issuer is required. The cryptography is checked directly.
+
+## 5. Versioning
+
+Breaking changes use a new URI (`…/trust-verdict/v2`). Agents that don't recognize the extension
+ignore the `risk_data` / `Task.metadata` block and proceed with the base flow (backward compatible).
+
+## References
+
+- Canonical spec + schema: <https://fidacy.com/a2a/extensions/trust-verdict/v1> · [fidacy-open/spec](https://github.com/fidacy/fidacy-open/tree/main/spec)
+- Open-source verifier: [`@fidacy/verify`](https://www.npmjs.com/package/@fidacy/verify)
+- Public JWKS: <https://api.fidacy.com/.well-known/jwks.json>

--- a/extensions/fidacy-trust-verdict/v1/spec.md
+++ b/extensions/fidacy-trust-verdict/v1/spec.md
@@ -43,26 +43,26 @@ The extension does not invent a new container. The verdict travels in existing f
 - **Plain A2A flows:** in `Task.metadata` as `{ "fidacy_assessment": { … } }`, where the signed JWS
   is at `fidacy_assessment.risk_payload.jws`. The decision also maps to an official A2A Task state:
 
-  | `decision` | recommended Task state    |
-  | ---------- | ------------------------- |
-  | `approve`  | `TASK_STATE_WORKING`      |
-  | `review`   | `TASK_STATE_AUTH_REQUIRED`|
-  | `deny`     | `TASK_STATE_REJECTED`     |
+  | `decision` | recommended Task state     |
+  | ---------- | -------------------------- |
+  | `approve`  | `TASK_STATE_WORKING`       |
+  | `review`   | `TASK_STATE_AUTH_REQUIRED` |
+  | `deny`     | `TASK_STATE_REJECTED`      |
 
 ## 3. The signed verdict (source of truth)
 
 The JWS (`vc_jws` / `risk_payload.jws`) is a compact **EdDSA** JWS, `typ: application/vc+jws`, whose
 verified claims are the verdict:
 
-| Claim           | Meaning                                                  |
-| --------------- | -------------------------------------------------------- |
-| `issuer`        | `did:web:fidacy.com#<kid>` (kid = JWKS key id)           |
-| `subject`       | the agent/mandate assessed                               |
-| `decision`      | `approve` \| `review` \| `deny`                          |
-| `score`         | 0-100                                                    |
-| `model_version` | scoring model id                                         |
-| `assessed_at`   | ISO 8601                                                 |
-| `signals`       | opaque advisory signals (not normative)                 |
+| Claim           | Meaning                                                  |            |        |
+| --------------- | -------------------------------------------------------- |            |        |
+| `issuer`        | `did:web:fidacy.com#<kid>` (kid = JWKS key id)           |            |        |
+| `subject`       | the agent/mandate assessed                               |            |        |
+| `decision`      | `approve` \                                              | `review` \ | `deny` |
+| `score`         | 0-100                                                    |            |        |
+| `model_version` | scoring model id                                         |            |        |
+| `assessed_at`   | ISO 8601                                                 |            |        |
+| `signals`       | opaque advisory signals (not normative)                  |            |        |
 
 ## 4. Verification (normative)
 

--- a/extensions/fidacy-trust-verdict/v1/spec.md
+++ b/extensions/fidacy-trust-verdict/v1/spec.md
@@ -54,15 +54,15 @@ The extension does not invent a new container. The verdict travels in existing f
 The JWS (`vc_jws` / `risk_payload.jws`) is a compact **EdDSA** JWS, `typ: application/vc+jws`, whose
 verified claims are the verdict:
 
-| Claim           | Meaning                                                  |            |        |
-| --------------- | -------------------------------------------------------- |            |        |
-| `issuer`        | `did:web:fidacy.com#<kid>` (kid = JWKS key id)           |            |        |
-| `subject`       | the agent/mandate assessed                               |            |        |
-| `decision`      | `approve` \                                              | `review` \ | `deny` |
-| `score`         | 0-100                                                    |            |        |
-| `model_version` | scoring model id                                         |            |        |
-| `assessed_at`   | ISO 8601                                                 |            |        |
-| `signals`       | opaque advisory signals (not normative)                  |            |        |
+| Claim           | Meaning                                        |
+| --------------- | ---------------------------------------------- |
+| `issuer`        | `did:web:fidacy.com#<kid>` (kid = JWKS key id) |
+| `subject`       | the agent/mandate assessed                     |
+| `decision`      | `approve` \| `review` \| `deny`                |
+| `score`         | 0-100                                          |
+| `model_version` | scoring model id                               |
+| `assessed_at`   | ISO 8601                                       |
+| `signals`       | opaque advisory signals (not normative)        |
 
 ## 4. Verification (normative)
 


### PR DESCRIPTION
Proposes a new sample extension demonstrating a **trust verdict** for agent payments: a signed approve/review/deny decision that any party verifies independently against a public JWKS, with no trust in the issuer required. It is the neutral complement to the existing `a2a-x402` (settlement) and AP2 (authorization) work, and it fills the AP2 `risk_data` slot, which is reserved but implementation-defined.

It does not invent a new container. The verdict rides the existing AP2 `risk_data` field or A2A `Task.metadata`, and the signed EdDSA JWS is the source of truth.

Layout matches `secure-passport` (README, HOWTORUN, v1/spec.md, v1/samples/python). The Python sample runs end to end (assess over A2A, then verify the JWS against the public JWKS) and prints `signature valid: True`. Apache-2.0.

Live, verifiable references:
- Spec + URI: https://fidacy.com/a2a/extensions/trust-verdict/v1
- Open-source verifier: https://www.npmjs.com/package/@fidacy/verify
- Public JWKS: https://api.fidacy.com/.well-known/jwks.json

Per CONTRIBUTING, glad to discuss or adjust to your conventions. If a maintainer is interested in sponsoring it toward experimental status under the extension governance framework, I would happily follow that process.