### PR TITLE
docs: Fix Helloworld Quick Start and document uv non-project alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,25 @@ Our samples demonstrate how easily complex multi-agent problems can be solved ac
 Get up and running immediately by launching a Helloworld agent and communicating with it via our Python CLI host.
 
 1. **Start the Agent Server**:
-   Open a terminal and start the Helloworld agent server:
+   Open a terminal, navigate to the Helloworld agent directory, set up a virtual environment, install the dependencies, and start the server:
 
    ```bash
    cd samples/python/agents/helloworld
-   uv run .
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   python __main__.py
    ```
 
 2. **Run the Host Client**:
-   Open a second terminal and run the CLI client to send a task to the agent:
+   Open a second terminal, navigate to the Helloworld agent directory, activate the virtual environment, and run the test client:
 
    ```bash
    cd samples/python/agents/helloworld
-   uv run test_client.py
+   source .venv/bin/activate
+   python test_client.py
    ```
+
 
 ## Repository Structure
 

--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -5,7 +5,7 @@ This code is used to demonstrate A2A capabilities as the spec progresses.
 Samples are divided into 3 sub directories:
 
 * [**Common**](/samples/python/common)
-    * NOTE: Do not use this code for further development. Use the A2A Python SDK here: https://github.com/google/a2a-python/
+  * NOTE: Do not use this code for further development. Use the A2A Python SDK here: <https://github.com/google/a2a-python/>
 
 * [**Agents**](/samples/python/agents/README.md)
 Sample agents written in multiple frameworks that perform example tasks with tools. These all use the common A2AServer.
@@ -72,12 +72,26 @@ For example, to run the `langgraph` agent:
 ---
 **NOTE:**
 This is sample code and not production-quality libraries.
+
 ---
 
 
 ## Disclaimer
-Important: The sample code provided is for demonstration purposes and illustrates the mechanics of the Agent-to-Agent (A2A) protocol. When building production applications, it is critical to treat any agent operating outside of your direct control as a potentially untrusted entity.
 
-All data received from an external agent—including but not limited to its AgentCard, messages, artifacts, and task statuses—should be handled as untrusted input. For example, a malicious agent could provide an AgentCard containing crafted data in its fields (e.g., description, name, skills.description). If this data is used without sanitization to construct prompts for a Large Language Model (LLM), it could expose your application to prompt injection attacks.  Failure to properly validate and sanitize this data before use can introduce security vulnerabilities into your application.
+**Important:** The sample code provided is for demonstration purposes and
+illustrates the mechanics of the Agent-to-Agent (A2A) protocol. When building
+production applications, it is critical to treat any agent operating outside of
+your direct control as a potentially untrusted entity.
 
-Developers are responsible for implementing appropriate security measures, such as input validation and secure handling of credentials to protect their systems and users.
+All data received from an external agent—including but not limited to its
+AgentCard, messages, artifacts, and task statuses—should be handled as
+untrusted input. For example, a malicious agent could provide an AgentCard
+containing crafted data in its fields (e.g., description, name,
+skills.description). If this data is used without sanitization to construct
+prompts for a Large Language Model (LLM), it could expose your application to
+prompt injection attacks. Failure to properly validate and sanitize this data
+before use can introduce security vulnerabilities into your application.
+
+Developers are responsible for implementing appropriate security measures, such
+as input validation and secure handling of credentials to protect their systems
+and users.

--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -43,6 +43,12 @@ For example, to run the `helloworld` agent with a virtual environment:
     ```bash
     python __main__.py
     ```
+4. In another terminal, run the test client:
+    ```bash
+    cd samples/python/agents/helloworld
+    source .venv/bin/activate
+    python test_client.py
+    ```
 
 > [!TIP]
 > **Alternative: Using `uv` with `requirements.txt`**
@@ -66,6 +72,11 @@ For example, to run the `langgraph` agent:
     ```
 2. Run the agent server:
     ```bash
+    uv run .
+    ```
+3. In another terminal, navigate to the CLI directory and run the client:
+    ```bash
+    cd samples/python/hosts/cli
     uv run .
     ```
 

--- a/samples/python/README.md
+++ b/samples/python/README.md
@@ -7,41 +7,70 @@ Samples are divided into 3 sub directories:
 * [**Common**](/samples/python/common)
     * NOTE: Do not use this code for further development. Use the A2A Python SDK here: https://github.com/google/a2a-python/
 
-* [**Agents**](/samples/python/agents/README.md)  
+* [**Agents**](/samples/python/agents/README.md)
 Sample agents written in multiple frameworks that perform example tasks with tools. These all use the common A2AServer.
 
-* [**Hosts**](/samples/python/hosts/README.md)  
+* [**Hosts**](/samples/python/hosts/README.md)
 Host applications that use the A2AClient. Includes a CLI which shows simple task completion with a single agent, a mesop web application that can speak to multiple agents, and an orchestrator agent that delegates tasks to one of multiple remote A2A agents.
 
 ## Prerequisites
 
-- Python 3.13 or higher
-- [UV](https://docs.astral.sh/uv/)
+- **Python**: Version 3.10 or higher (some samples may require Python 3.13)
+- **pip** (for samples configured with `requirements.txt`)
+- **[uv](https://docs.astral.sh/uv/)** (for samples configured with `pyproject.toml`)
 
 ## Running the Samples
 
-Run one (or more) [agent](/samples/python/agents/README.md) A2A server and one of the [host applications](/samples/python/hosts/README.md). 
+Run one (or more) [agent](/samples/python/agents/README.md) A2A server and one of the [host applications](/samples/python/hosts/README.md).
 
-The following example will run the langgraph agent with the python CLI host:
+Depending on how the specific sample is configured, you can run it either using **standard python & pip** (if a `requirements.txt` file is present) or **uv** (if a `pyproject.toml` file is present).
+
+### Option A: Using standard pip & virtualenv (for samples with `requirements.txt`)
+
+For example, to run the `helloworld` agent with a virtual environment:
+
+1. Navigate to the agent directory:
+    ```bash
+    cd samples/python/agents/helloworld
+    ```
+2. Set up a virtual environment and install dependencies:
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
+    ```
+3. Run the agent server:
+    ```bash
+    python __main__.py
+    ```
+
+> [!TIP]
+> **Alternative: Using `uv` with `requirements.txt`**
+> If you prefer using `uv` but want to avoid parent workspace conflicts, you can use `uv` in non-project mode:
+> - **With a virtual environment**:
+>   ```bash
+>   uv venv
+>   source .venv/bin/activate
+>   uv pip install -r requirements.txt
+>   python __main__.py
+>   ```
+
+
+### Option B: Using uv (for samples with `pyproject.toml`)
+
+For example, to run the `langgraph` agent:
 
 1. Navigate to the agent directory:
     ```bash
     cd samples/python/agents/langgraph
     ```
-2. Run an agent:
+2. Run the agent server:
     ```bash
     uv run .
     ```
-3. In another terminal, navigate to the CLI directory:
-    ```bash
-    cd samples/python/hosts/cli
-    ```
-4. Run the example client
-    ```
-    uv run .
-    ```
+
 ---
-**NOTE:** 
+**NOTE:**
 This is sample code and not production-quality libraries.
 ---
 


### PR DESCRIPTION


## Description
This PR resolves issue #635  where the root README Quick Start for the Python helloworld sample was conflicting with `uv`'s parent project traversal. 

Since `helloworld` does not contain a `pyproject.toml` file (by design, to favor standard `requirements.txt` / pip environments), running `uv run` inside the folder triggers resolution using the parent project's `samples/python/pyproject.toml` and locks the environment, leading to a `ModuleNotFoundError` on startup.

## Changes
1. **Root README.md**: 
   - Updated Quick Start instructions to guide users to create a virtual environment (`python -m venv .venv`) and install dependencies using standard `pip` (`pip install -r requirements.txt`).
2. **samples/python/README.md**:
   - Re-organized the main running instructions into distinct options: **Option A** (standard `pip` + virtualenv) and **Option B** (`uv` for `pyproject.toml` projects).
   - Added an alternative tips section explaining how to run standard `requirements.txt` samples with `uv` using non-project mode (`uv venv` and `uv pip install`).
   - Cleaned up trailing whitespace and ensured standard newline endings.

## Verification
- Verified both README files are clean of trailing whitespace.
- Verified that running `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt` builds the virtual environment with the correct SDK version (`a2a-sdk>=1.1.0`) and starts the server successfully.
