### PR TITLE
fix(dotnet): prevent shell command injection in CLI Agent (fixes #636)

### DIFF
--- a/samples/dotnet/A2ACliDemo/CLIServer/CLIAgent.cs
+++ b/samples/dotnet/A2ACliDemo/CLIServer/CLIAgent.cs
@@ -23,16 +23,26 @@ internal record CommandExecutionResult(
 /// <summary>
 /// A CLI agent that can execute command-line tools and return results.
 /// This demonstrates how to bridge AI agents with system-level operations.
+/// 
+/// IMPORTANT: This sample should NOT be exposed to untrusted clients.
+/// The command bridge runs local system commands and is intended for
+/// development and trusted environments only.
 /// </summary>
 public class CLIAgent
 {
+    /// <summary>
+    /// Allowed commands — safe, read-only system utilities.
+    /// Interpreters and package managers (python, node, npm, dotnet) are
+    /// intentionally excluded: they accept arbitrary code as arguments,
+    /// which cannot be meaningfully constrained by an allowlist.
+    /// </summary>
     private static readonly HashSet<string> AllowedCommands = new()
     {
         // Safe read-only commands
         "dir", "ls", "pwd", "whoami", "date", "time",
         "echo", "cat", "type", "head", "tail",
         "ps", "tasklist", "netstat", "ipconfig", "ping",
-        "git", "dotnet", "node", "npm", "python"
+        "git"
     };
 
     /// <summary>
@@ -94,14 +104,16 @@ public class CLIAgent
 
     /// <summary>
     /// Executes a CLI command safely with security checks.
-    /// This is the core functionality that makes this agent useful!
+    /// Uses direct process invocation (no shell) — the command runs as the
+    /// executable and arguments are passed as an argv array. This prevents
+    /// shell metacharacter injection (;, |, &amp;&amp;, $(), backticks).
     /// </summary>
     private async Task<string> ExecuteCommandAsync(string input, CancellationToken cancellationToken)
     {
-        // Parse command and arguments
+        // Parse command and arguments into a list
         var parts = ParseCommand(input);
         var command = parts.Command;
-        var arguments = parts.Arguments;
+        var argumentList = parts.Arguments;
 
         // Security check: Only allow whitelisted commands
         if (!IsCommandAllowed(command))
@@ -110,25 +122,22 @@ public class CLIAgent
                    $"Allowed commands: {string.Join(", ", AllowedCommands)}";
         }
 
-        // Execute the command
+        // Execute the command directly — no shell, no /bin/bash -c, no cmd /c
         using var process = new Process();
 
-        // Configure process based on operating system
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            process.StartInfo.FileName = "cmd.exe";
-            process.StartInfo.Arguments = $"/c {command} {arguments}";
-        }
-        else
-        {
-            process.StartInfo.FileName = "/bin/bash";
-            process.StartInfo.Arguments = $"-c \"{command} {arguments}\"";
-        }
-
+        process.StartInfo.FileName = command;
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
         process.StartInfo.CreateNoWindow = true;
+
+        // Pass arguments as a proper argv array. ArgumentList handles
+        // platform-specific quoting and never invokes a shell, so
+        // metacharacters arrive as literal argv entries.
+        foreach (var arg in argumentList)
+        {
+            process.StartInfo.ArgumentList.Add(arg);
+        }
 
         var output = new List<string>();
         var errors = new List<string>();
@@ -153,10 +162,8 @@ public class CLIAgent
         // Wait for completion with timeout
         await process.WaitForExitAsync(cancellationToken);
 
-        // Process has completed normally
-
         var result = new CommandExecutionResult(
-            Command: $"{command} {arguments}",
+            Command: $"{command} {string.Join(" ", argumentList)}",
             ExitCode: process.ExitCode,
             Output: output.AsReadOnly(),
             Errors: errors.AsReadOnly(),
@@ -167,24 +174,35 @@ public class CLIAgent
     }
 
     /// <summary>
-    /// Parses user input into command and arguments.
+    /// Parses user input into a command name and an argument list.
+    /// Arguments are returned as individual tokens — never interpolated
+    /// into a shell command string.
     /// </summary>
-    private static (string Command, string Arguments) ParseCommand(string input)
+    private static (string Command, List<string> Arguments) ParseCommand(string input)
     {
         var trimmed = input.Trim();
         var spaceIndex = trimmed.IndexOf(' ');
 
         if (spaceIndex == -1)
         {
-            return (trimmed, string.Empty);
+            return (trimmed, new List<string>());
         }
 
-        return (trimmed.Substring(0, spaceIndex), trimmed.Substring(spaceIndex + 1));
+        var command = trimmed.Substring(0, spaceIndex);
+        var argsString = trimmed.Substring(spaceIndex + 1);
+
+        // Split remaining text into individual argument tokens.
+        // Simple whitespace split is sufficient for the sample's
+        // read-only, non-shell command set.
+        var args = argsString
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        return (command, args);
     }
 
     /// <summary>
     /// Security check: Ensures only safe commands are executed.
-    /// This is CRITICAL for security!
     /// </summary>
     private static bool IsCommandAllowed(string command)
     {

--- a/samples/go/agents/helloworld/test_client.go
+++ b/samples/go/agents/helloworld/test_client.go
@@ -31,7 +31,7 @@ func getAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch agent card: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch agent card: status code %d", resp.StatusCode)

--- a/samples/go/agents/sign-and-verify-agent-card/test_client.go
+++ b/samples/go/agents/sign-and-verify-agent-card/test_client.go
@@ -30,7 +30,7 @@ func keyProvider(keyID, jku string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): %w", jku, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): status code %d", jku, resp.StatusCode)


### PR DESCRIPTION
## Summary

Fixes the shell command injection vulnerability reported in #636.

**Root cause:** `ParseCommand` only allowlisted the first token, then interpolated the entire string into `/bin/bash -c "{command} {arguments}"`. Shell metacharacters (`;`, `|`, `&&`, `$()`, backticks) in the argument portion bypassed the allowlist entirely.

**Fix:** Replace shell-based execution with direct process invocation:

1. **No shell** — Execute allowlisted commands directly via `ProcessStartInfo`, never through `/bin/bash -c` or `cmd.exe /c`
2. **ArgumentList** — Parse arguments into a `List<string>`, pass via `ArgumentList` (argv). `ArgumentList` handles platform-specific quoting; metacharacters arrive as literal argv entries
3. **Narrowed allowlist** — Remove interpreters (`python`, `node`, `npm`, `dotnet`) — they accept arbitrary code as arguments
4. **Security warning** — Added doc comment that this sample should not be exposed to untrusted clients

Credit to @chopmob-cloud for the detailed root-cause analysis and fix direction in #636.