### PR TITLE
fix(go): check/ignore error from resp.Body.Close in test clients

### DIFF
--- a/samples/go/agents/helloworld/test_client.go
+++ b/samples/go/agents/helloworld/test_client.go
@@ -31,7 +31,7 @@ func getAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch agent card: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch agent card: status code %d", resp.StatusCode)

--- a/samples/go/agents/sign-and-verify-agent-card/test_client.go
+++ b/samples/go/agents/sign-and-verify-agent-card/test_client.go
@@ -30,7 +30,7 @@ func keyProvider(keyID, jku string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): %w", jku, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): status code %d", jku, resp.StatusCode)


### PR DESCRIPTION

## Description
This hotfix addresses Go linter warnings where the error return value from `resp.Body.Close()` was unchecked.

## Changes
- **samples/go/agents/helloworld/test_client.go**: Checked/ignored the body close error using an anonymous deferred function.
- **samples/go/agents/sign-and-verify-agent-card/test_client.go**: Checked/ignored the body close error using an anonymous deferred function.
