### PR TITLE
fix(go/helloworld): ignore linter error from resp.Body.Close in test client

### DIFF
--- a/samples/go/agents/helloworld/test_client.go
+++ b/samples/go/agents/helloworld/test_client.go
@@ -31,7 +31,7 @@ func getAgentCard(ctx context.Context) (*a2a.AgentCard, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch agent card: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch agent card: status code %d", resp.StatusCode)


### PR DESCRIPTION


## Description
This hotfix addresses a Go linter warning where the error return value from `resp.Body.Close()` was unchecked in the helloworld test client.

## Changes
- **samples/go/agents/helloworld/test_client.go**: Checked/ignored the body close error using an anonymous deferred function.
