### PR TITLE
fix(go/sign-and-verify): fix linter error from resp.Body.Close in test client

### DIFF
--- a/samples/go/agents/sign-and-verify-agent-card/test_client.go
+++ b/samples/go/agents/sign-and-verify-agent-card/test_client.go
@@ -30,7 +30,7 @@ func keyProvider(keyID, jku string) (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): %w", jku, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch public key from JKU URL (%s): status code %d", jku, resp.StatusCode)


### PR DESCRIPTION


## Description
This hotfix addresses a Go linter warning where the error return value from `resp.Body.Close()` was unchecked in the sign-and-verify-agent-card test client.

## Changes
- **samples/go/agents/sign-and-verify-agent-card/test_client.go**: Checked/ignored the body close error using an anonymous deferred function.
