### PR TITLE
ci(linter): disable Go and Go modules validation in super-linter

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -52,6 +52,8 @@ jobs:
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+          VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
 
   go-lint:
     name: Lint Go


### PR DESCRIPTION
Disables Go and Go modules validation in the GitHub Super Linter step. This avoids duplicate checking since Go module linting is handled by a separate dedicated job in the workflow.