### PR TITLE
fix: use child task IDs in a2a_mcp workflows

### DIFF
--- a/samples/python/agents/a2a_mcp/src/a2a_mcp/agents/orchestrator_agent.py
+++ b/samples/python/agents/a2a_mcp/src/a2a_mcp/agents/orchestrator_agent.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 import json
 import logging
 
@@ -39,9 +40,7 @@ class OrchestratorAgent(BaseAgent):
         client = genai.Client()
         response = client.models.generate_content(
             model='gemini-2.0-flash',
-            contents=prompts.SUMMARY_COT_INSTRUCTIONS.replace(
-                '{travel_data}', str(self.results)
-            ),
+            contents=prompts.SUMMARY_COT_INSTRUCTIONS.replace('{travel_data}', str(self.results)),
             config={'temperature': 0.0},
         )
         return response.text
@@ -51,9 +50,7 @@ class OrchestratorAgent(BaseAgent):
             client = genai.Client()
             response = client.models.generate_content(
                 model='gemini-2.0-flash',
-                contents=prompts.QA_COT_PROMPT.replace(
-                    '{TRIP_CONTEXT}', str(self.travel_context)
-                )
+                contents=prompts.QA_COT_PROMPT.replace('{TRIP_CONTEXT}', str(self.travel_context))
                 .replace('{CONVERSATION_HISTORY}', str(self.query_history))
                 .replace('{TRIP_QUESTION}', question),
                 config={
@@ -66,9 +63,7 @@ class OrchestratorAgent(BaseAgent):
             logger.info(f'Error answering user question: {e}')
         return '{"can_answer": "no", "answer": "Cannot answer based on provided context"}'
 
-    def set_node_attributes(
-        self, node_id, task_id=None, context_id=None, query=None
-    ):
+    def set_node_attributes(self, node_id, task_id=None, context_id=None, query=None):
         attr_val = {}
         if task_id:
             attr_val['task_id'] = task_id
@@ -81,21 +76,23 @@ class OrchestratorAgent(BaseAgent):
 
     def add_graph_node(
         self,
-        task_id,
         context_id,
         query: str,
         node_id: str = None,
         node_key: str = None,
         node_label: str = None,
     ) -> WorkflowNode:
-        """Add a node to the graph."""
-        node = WorkflowNode(
-            task=query, node_key=node_key, node_label=node_label
-        )
+        """Add a node to the graph.
+
+        Child nodes must not inherit the orchestrator's task_id. A2A
+        treats a present taskId as a resume of a task on the receiving
+        agent, and the child has not created that task yet.
+        """
+        node = WorkflowNode(task=query, node_key=node_key, node_label=node_label)
         self.graph.add_node(node)
         if node_id:
             self.graph.add_edge(node_id, node.id)
-        self.set_node_attributes(node.id, task_id, context_id, query)
+        self.set_node_attributes(node.id, context_id=context_id, query=query)
         return node
 
     def clear_state(self):
@@ -104,9 +101,7 @@ class OrchestratorAgent(BaseAgent):
         self.travel_context.clear()
         self.query_history.clear()
 
-    async def stream(
-        self, query, context_id, task_id
-    ) -> AsyncIterable[dict[str, any]]:
+    async def stream(self, query, context_id, task_id) -> AsyncIterable[dict[str, any]]:
         """Execute and stream response."""
         logger.info(
             f'Running {self.agent_name} stream for session {context_id}, task {task_id} - {query}'
@@ -124,7 +119,6 @@ class OrchestratorAgent(BaseAgent):
         if not self.graph:
             self.graph = WorkflowGraph()
             planner_node = self.add_graph_node(
-                task_id=task_id,
                 context_id=context_id,
                 query=query,
                 node_key='planner',
@@ -138,59 +132,45 @@ class OrchestratorAgent(BaseAgent):
 
         # This loop can be avoided if the workflow graph is dynamic or
         # is built from the results of the planner when the planner
-        # iself is not a part of the graph.
+        # itself is not a part of the graph.
         # TODO: Make the graph dynamically iterable over edges
         while True:
-            # Set attributes on the node so we propagate task and context
+            # Propagate context only. Child task ids are stored on the
+            # node from the child's stream and must not be overwritten
+            # with the orchestrator's task_id.
             self.set_node_attributes(
                 node_id=start_node_id,
-                task_id=task_id,
                 context_id=context_id,
             )
             # Resume workflow, used when the workflow nodes are updated.
             should_resume_workflow = False
-            async for chunk in self.graph.run_workflow(
-                start_node_id=start_node_id
-            ):
+            async for chunk in self.graph.run_workflow(start_node_id=start_node_id):
                 if isinstance(chunk.root, SendStreamingMessageSuccessResponse):
-                    # The graph node retured TaskStatusUpdateEvent
+                    # The graph node returned TaskStatusUpdateEvent
                     # Check if the node is complete and continue to the next node
                     if isinstance(chunk.root.result, TaskStatusUpdateEvent):
                         task_status_event = chunk.root.result
                         context_id = task_status_event.context_id
-                        if (
-                            task_status_event.status.state
-                            == TaskState.completed
-                            and context_id
-                        ):
-                            ## yeild??
+                        if task_status_event.status.state == TaskState.completed and context_id:
+                            ## yield??
                             continue
-                        if (
-                            task_status_event.status.state
-                            == TaskState.input_required
-                        ):
-                            question = task_status_event.status.message.parts[
-                                0
-                            ].root.text
+                        if task_status_event.status.state == TaskState.input_required:
+                            question = task_status_event.status.message.parts[0].root.text
 
                             try:
-                                answer = json.loads(
-                                    self.answer_user_question(question)
-                                )
+                                answer = json.loads(self.answer_user_question(question))
                                 logger.info(f'Agent Answer {answer}')
                                 if answer['can_answer'] == 'yes':
                                     # Orchestrator can answer on behalf of the user set the query
                                     # Resume workflow from paused state.
                                     query = answer['answer']
                                     start_node_id = self.graph.paused_node_id
-                                    self.set_node_attributes(
-                                        node_id=start_node_id, query=query
-                                    )
+                                    self.set_node_attributes(node_id=start_node_id, query=query)
                                     should_resume_workflow = True
                             except Exception:
                                 logger.info('Cannot convert answer data')
 
-                    # The graph node retured TaskArtifactUpdateEvent
+                    # The graph node returned TaskArtifactUpdateEvent
                     # Store the node and continue.
                     if isinstance(chunk.root.result, TaskArtifactUpdateEvent):
                         artifact = chunk.root.result.artifact
@@ -205,11 +185,8 @@ class OrchestratorAgent(BaseAgent):
                             )
                             # Define the edges
                             current_node_id = start_node_id
-                            for idx, task_data in enumerate(
-                                artifact_data['tasks']
-                            ):
+                            for idx, task_data in enumerate(artifact_data['tasks']):
                                 node = self.add_graph_node(
-                                    task_id=task_id,
                                     context_id=context_id,
                                     query=task_data['description'],
                                     node_id=current_node_id,

--- a/samples/python/agents/a2a_mcp/src/a2a_mcp/common/child_message.py
+++ b/samples/python/agents/a2a_mcp/src/a2a_mcp/common/child_message.py
@@ -1,0 +1,38 @@
+# ruff: noqa
+"""Helpers for child-agent A2A message payloads."""
+
+from typing import Any
+from uuid import uuid4
+
+
+def create_child_message_payload(
+    query: str,
+    context_id: str,
+    task_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a child-agent message payload.
+
+    A2A treats a present taskId as a resume of an existing task on the
+    receiving server. New work must omit taskId so the child creates one.
+    """
+    message: dict[str, Any] = {
+        'role': 'user',
+        'parts': [{'kind': 'text', 'text': query}],
+        'messageId': uuid4().hex,
+        'contextId': context_id,
+    }
+    if task_id:
+        message['taskId'] = task_id
+    return {'message': message}
+
+
+def child_task_id_from_result(result: object) -> str | None:
+    """Return the child-local task id from a streaming result, if present."""
+    event_task_id = getattr(result, 'task_id', None)
+    if isinstance(event_task_id, str) and event_task_id:
+        return event_task_id
+    # Task objects expose id plus a status; request wrappers expose only id.
+    result_id = getattr(result, 'id', None)
+    if isinstance(result_id, str) and result_id and hasattr(result, 'status'):
+        return result_id
+    return None

--- a/samples/python/agents/a2a_mcp/src/a2a_mcp/common/workflow.py
+++ b/samples/python/agents/a2a_mcp/src/a2a_mcp/common/workflow.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 import json
 import logging
 import uuid
@@ -18,6 +19,10 @@ from a2a.types import (
     TaskArtifactUpdateEvent,
     TaskState,
     TaskStatusUpdateEvent,
+)
+from a2a_mcp.common.child_message import (
+    child_task_id_from_result,
+    create_child_message_payload,
 )
 from a2a_mcp.common.utils import get_mcp_server_config
 from a2a_mcp.mcp import client
@@ -61,21 +66,15 @@ class WorkflowNode:
     async def get_planner_resource(self) -> AgentCard | None:
         logger.info(f'Getting resource for node {self.id}')
         config = get_mcp_server_config()
-        async with client.init_session(
-            config.host, config.port, config.transport
-        ) as session:
-            response = await client.find_resource(
-                session, 'resource://agent_cards/planner_agent'
-            )
+        async with client.init_session(config.host, config.port, config.transport) as session:
+            response = await client.find_resource(session, 'resource://agent_cards/planner_agent')
             data = json.loads(response.contents[0].text)
             return AgentCard(**data['agent_card'][0])
 
     async def find_agent_for_task(self) -> AgentCard | None:
         logger.info(f'Find agent for task - {self.task}')
         config = get_mcp_server_config()
-        async with client.init_session(
-            config.host, config.port, config.transport
-        ) as session:
+        async with client.init_session(config.host, config.port, config.transport) as session:
             result = await client.find_agent(session, self.task)
             agent_card_json = json.loads(result.content[0].text)
             logger.debug(f'Found agent {agent_card_json} for task {self.task}')
@@ -84,7 +83,7 @@ class WorkflowNode:
     async def run_node(
         self,
         query: str,
-        task_id: str,
+        task_id: str | None,
         context_id: str,
     ) -> AsyncIterable[dict[str, any]]:
         logger.info(f'Executing node {self.id}')
@@ -96,24 +95,20 @@ class WorkflowNode:
         async with httpx.AsyncClient() as httpx_client:
             client = A2AClient(httpx_client, agent_card)
 
-            payload: dict[str, any] = {
-                'message': {
-                    'role': 'user',
-                    'parts': [{'kind': 'text', 'text': query}],
-                    'messageId': uuid4().hex,
-                    'taskId': task_id,
-                    'contextId': context_id,
-                },
-            }
+            payload = create_child_message_payload(
+                query=query,
+                context_id=context_id,
+                task_id=task_id,
+            )
             request = SendStreamingMessageRequest(
                 id=str(uuid4()), params=MessageSendParams(**payload)
             )
             response_stream = client.send_message_streaming(request)
             async for chunk in response_stream:
                 # Save the artifact as a result of the node
-                if isinstance(
-                    chunk.root, SendStreamingMessageSuccessResponse
-                ) and (isinstance(chunk.root.result, TaskArtifactUpdateEvent)):
+                if isinstance(chunk.root, SendStreamingMessageSuccessResponse) and (
+                    isinstance(chunk.root.result, TaskArtifactUpdateEvent)
+                ):
                     artifact = chunk.root.result.artifact
                     self.results = artifact
                 yield chunk
@@ -142,9 +137,7 @@ class WorkflowGraph:
 
         self.graph.add_edge(from_node_id, to_node_id)
 
-    async def run_workflow(
-        self, start_node_id: str | None = None
-    ) -> AsyncIterable[dict[str, any]]:
+    async def run_workflow(self, start_node_id: str | None = None) -> AsyncIterable[dict[str, any]]:
         logger.info('Executing workflow graph')
         if not start_node_id or start_node_id not in self.nodes:
             start_nodes = [n for n, d in self.graph.in_degree() if d == 0]
@@ -172,21 +165,21 @@ class WorkflowGraph:
                 # When the workflow node is paused, do not yield any chunks
                 # but, let the loop complete.
                 if node.state != Status.PAUSED:
-                    if isinstance(
-                        chunk.root, SendStreamingMessageSuccessResponse
-                    ) and (
-                        isinstance(chunk.root.result, TaskStatusUpdateEvent)
-                    ):
-                        task_status_event = chunk.root.result
-                        context_id = task_status_event.context_id
-                        if (
-                            task_status_event.status.state
-                            == TaskState.input_required
-                            and context_id
-                        ):
-                            node.state = Status.PAUSED
-                            self.state = Status.PAUSED
-                            self.paused_node_id = node.id
+                    if isinstance(chunk.root, SendStreamingMessageSuccessResponse):
+                        result = chunk.root.result
+                        child_task_id = child_task_id_from_result(result)
+                        if child_task_id:
+                            self.set_node_attribute(node_id, 'task_id', child_task_id)
+                        if isinstance(result, TaskStatusUpdateEvent):
+                            task_status_event = result
+                            context_id = task_status_event.context_id
+                            if (
+                                task_status_event.status.state == TaskState.input_required
+                                and context_id
+                            ):
+                                node.state = Status.PAUSED
+                                self.state = Status.PAUSED
+                                self.paused_node_id = node.id
                     yield chunk
             if self.state == Status.PAUSED:
                 break

--- a/samples/python/agents/a2a_mcp/tests/test_workflow_task_id.py
+++ b/samples/python/agents/a2a_mcp/tests/test_workflow_task_id.py
@@ -1,0 +1,143 @@
+# ruff: noqa
+import ast
+import importlib.util
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+# Import the helper by file path. Importing a2a_mcp as a package runs
+# a2a_mcp.__init__, which requires click and other runtime deps.
+_SAMPLE_ROOT = Path(__file__).resolve().parents[1]
+_HELPER_PATH = _SAMPLE_ROOT / 'src' / 'a2a_mcp' / 'common' / 'child_message.py'
+_SPEC = importlib.util.spec_from_file_location('child_message', _HELPER_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_CHILD_MESSAGE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CHILD_MESSAGE)
+create_child_message_payload = _CHILD_MESSAGE.create_child_message_payload
+child_task_id_from_result = _CHILD_MESSAGE.child_task_id_from_result
+
+PARENT_TASK_ID = 'orchestrator-task-aaa'
+CHILD_TASK_ID = 'child-task-bbb'
+CONTEXT_ID = 'ctx-ccc'
+
+
+_FUNC_TYPES = (ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+def _parse_sample(relative_path: str) -> ast.Module:
+    return ast.parse((_SAMPLE_ROOT / relative_path).read_text())
+
+
+def _call_keywords(node: ast.AST, func_name: str) -> list[set[str]]:
+    found: list[set[str]] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        called = child.func
+        name = getattr(called, 'attr', getattr(called, 'id', None))
+        if name == func_name:
+            found.append({kw.arg for kw in child.keywords if kw.arg})
+    return found
+
+
+def test_first_child_message_omits_task_id() -> None:
+    payload = create_child_message_payload(
+        query='Plan a trip to Paris',
+        context_id=CONTEXT_ID,
+        task_id=None,
+    )
+
+    assert 'taskId' not in payload['message']
+    assert payload['message']['contextId'] == CONTEXT_ID
+    assert PARENT_TASK_ID not in payload['message'].values()
+
+
+def test_resume_send_reuses_child_task_id() -> None:
+    payload = create_child_message_payload(
+        query='Use the same dates',
+        context_id=CONTEXT_ID,
+        task_id=CHILD_TASK_ID,
+    )
+
+    assert payload['message']['taskId'] == CHILD_TASK_ID
+    assert payload['message']['taskId'] != PARENT_TASK_ID
+
+
+def test_workflow_stores_child_task_id_and_reuses_it_on_resume() -> None:
+    """First hop omits taskId; the child's returned id is reused on resume."""
+    node_attrs: dict[str, str] = {
+        'query': 'Plan a trip to Paris',
+        'context_id': CONTEXT_ID,
+    }
+
+    first = create_child_message_payload(
+        query=node_attrs['query'],
+        context_id=node_attrs['context_id'],
+        task_id=node_attrs.get('task_id'),
+    )
+    assert 'taskId' not in first['message']
+
+    child_task = SimpleNamespace(id=CHILD_TASK_ID, status='submitted')
+    status_event = SimpleNamespace(
+        task_id=CHILD_TASK_ID,
+        context_id=CONTEXT_ID,
+    )
+    stored_id = child_task_id_from_result(child_task)
+    assert stored_id == child_task_id_from_result(status_event) == CHILD_TASK_ID
+    assert stored_id != PARENT_TASK_ID
+    node_attrs['task_id'] = stored_id
+
+    resume = create_child_message_payload(
+        query='Use the same dates',
+        context_id=node_attrs['context_id'],
+        task_id=node_attrs.get('task_id'),
+    )
+    assert resume['message']['taskId'] == CHILD_TASK_ID
+    assert resume['message']['taskId'] != PARENT_TASK_ID
+
+
+def test_orchestrator_does_not_stamp_parent_task_id_on_child_nodes() -> None:
+    """Planner and follow-on nodes must not inherit the orchestrator task id."""
+    tree = _parse_sample('src/a2a_mcp/agents/orchestrator_agent.py')
+    add_graph_node = None
+    stream = None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == 'OrchestratorAgent':
+            for item in node.body:
+                if isinstance(item, _FUNC_TYPES):
+                    if item.name == 'add_graph_node':
+                        add_graph_node = item
+                    elif item.name == 'stream':
+                        stream = item
+    assert add_graph_node is not None
+    assert stream is not None
+
+    add_params = [arg.arg for arg in add_graph_node.args.args]
+    assert 'task_id' not in add_params
+
+    for keywords in _call_keywords(add_graph_node, 'set_node_attributes'):
+        assert 'task_id' not in keywords
+    for keywords in _call_keywords(stream, 'add_graph_node'):
+        assert 'task_id' not in keywords
+    for keywords in _call_keywords(stream, 'set_node_attributes'):
+        assert 'task_id' not in keywords
+
+
+def test_run_node_omits_task_id_unless_child_already_owns_it() -> None:
+    workflow_path = _SAMPLE_ROOT / 'src/a2a_mcp/common/workflow.py'
+    source = workflow_path.read_text()
+    assert "'taskId': task_id" not in source
+
+    tree = ast.parse(source)
+    run_node = None
+    run_workflow = None
+    for node in ast.walk(tree):
+        if isinstance(node, _FUNC_TYPES) and node.name == 'run_node':
+            run_node = node
+        if isinstance(node, _FUNC_TYPES) and node.name == 'run_workflow':
+            run_workflow = node
+    assert run_node is not None
+    assert run_workflow is not None
+    assert _call_keywords(run_node, 'create_child_message_payload')
+    assert _call_keywords(run_workflow, 'child_task_id_from_result')


### PR DESCRIPTION
## Summary

`WorkflowNode.run_node` forwarded the orchestrator's task ID to child agents. A2A interprets that ID as an existing task on the receiving agent, so the first child request failed with `TaskNotFoundError` because the child did not own that task.

This change stops `OrchestratorAgent` from assigning its task ID to graph nodes. `WorkflowNode.run_node` now omits `taskId` on the first child request, records the child-local ID returned by the stream, and reuses that ID when resuming work with the same child. The payload and task-ID extraction logic live in `a2a_mcp/common/child_message.py`.

Regression tests cover initial requests, resumed requests, streamed child task IDs, and node attribute handling.

## Testing

`uv run --no-sync pytest samples/python/agents/a2a_mcp/tests/test_workflow_task_id.py --verbose`

All five tests pass.
