### PR TITLE
fix: show tool names in history and return the model answer

### DIFF
--- a/samples/python/agents/a2a-mcp-without-framework/src/no_llm_framework/server/agent.py
+++ b/samples/python/agents/a2a-mcp-without-framework/src/no_llm_framework/server/agent.py
@@ -26,6 +26,16 @@ with Path(dir_path / 'called_tools_history.jinja').open('r') as f:
     called_tools_history_template = Template(f.read())
 
 
+def build_called_tool_record(tool: dict[str, Any], result: CallToolResult) -> dict[str, Any]:
+    """Build a called-tool history record matching called_tools_history.jinja."""
+    return {
+        'name': tool['name'],
+        'arguments': tool['arguments'],
+        'isError': result.isError,
+        'result': result.content[0].text,
+    }
+
+
 def stream_llm(prompt: str) -> Generator[str, None]:
     """Stream LLM response.
 
@@ -80,9 +90,7 @@ class Agent:
             return self.call_llm(question)
         tool_prompt = await get_mcp_tool_prompt(self.mcp_url)
         if called_tools:
-            called_tools_prompt = called_tools_history_template.render(
-                called_tools=called_tools
-            )
+            called_tools_prompt = called_tools_history_template.render(called_tools=called_tools)
         else:
             called_tools_prompt = ''
 
@@ -112,10 +120,7 @@ class Agent:
             tools (list[dict]): The tools to call.
         """
         return await asyncio.gather(
-            *[
-                call_mcp_tool(self.mcp_url, tool['name'], tool['arguments'])
-                for tool in tools
-            ]
+            *[call_mcp_tool(self.mcp_url, tool['name'], tool['arguments']) for tool in tools]
         )
 
     async def stream(self, question: str) -> AsyncGenerator[dict[str, Any]]:
@@ -128,48 +133,29 @@ class Agent:
             dict: Streaming output, including intermediate steps and final result.
         """
         called_tools = []
-        for i in range(10):
-            yield {
-                'is_task_complete': False,
-                'require_user_input': False,
-                'content': f'Step {i}',
-            }
-
-            response = ''
+        last_response = ''
+        for _ in range(10):
+            last_response = ''
             for chunk in await self.decide(question, called_tools):
-                response += chunk
+                last_response += chunk
                 yield {
                     'is_task_complete': False,
                     'require_user_input': False,
                     'content': chunk,
                 }
-            tools = self.extract_tools(response)
+            tools = self.extract_tools(last_response)
             if not tools:
                 break
             results = await self.call_tool(tools)
-
             called_tools += [
-                {
-                    'tool': tool['name'],
-                    'arguments': tool['arguments'],
-                    'isError': result.isError,
-                    'result': result.content[0].text,
-                }
+                build_called_tool_record(tool, result)
                 for tool, result in zip(tools, results, strict=True)
             ]
-            called_tools_history = called_tools_history_template.render(
-                called_tools=called_tools, question=question
-            )
-            yield {
-                'is_task_complete': False,
-                'require_user_input': False,
-                'content': called_tools_history,
-            }
 
         yield {
             'is_task_complete': True,
             'require_user_input': False,
-            'content': 'Task completed',
+            'content': last_response,
         }
 
 

--- a/samples/python/agents/a2a-mcp-without-framework/src/no_llm_framework/server/called_tools_history.jinja
+++ b/samples/python/agents/a2a-mcp-without-framework/src/no_llm_framework/server/called_tools_history.jinja
@@ -1,5 +1,6 @@
 Previous tools have been called. {% for tool in called_tools %}
 - Tool: {{ tool.name }}
 - Arguments: {{ tool.arguments }}
+- isError: {{ tool.isError }}
 - Result: {{ tool.result }}
 {% endfor %}

--- a/samples/python/agents/a2a-mcp-without-framework/tests/test_tool_history.py
+++ b/samples/python/agents/a2a-mcp-without-framework/tests/test_tool_history.py
@@ -1,0 +1,78 @@
+# ruff: noqa: S101
+import asyncio
+import sys
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'src'))
+
+from no_llm_framework.server.agent import (
+    Agent,
+    build_called_tool_record,
+    called_tools_history_template,
+)
+
+
+DECIDE_TURNS = 2
+
+
+def test_history_template_renders_name_from_builder() -> None:
+    tool = {
+        'name': 'fetch_A2A_documentation',
+        'arguments': {'query': 'A2A'},
+    }
+    result = SimpleNamespace(
+        isError=False,
+        content=[SimpleNamespace(text='protocol overview')],
+    )
+
+    record = build_called_tool_record(tool, result)
+    rendered = called_tools_history_template.render(called_tools=[record])
+
+    assert record['name'] == 'fetch_A2A_documentation'
+    assert 'tool' not in record
+    assert '- Tool: fetch_A2A_documentation' in rendered
+    assert '- isError: False' in rendered
+    assert 'protocol overview' in rendered
+
+
+def test_stream_complete_event_uses_model_answer() -> None:
+    tool_call = '```json\n[{"name": "fetch_A2A_documentation", "arguments": {"query": "A2A"}}]\n```'
+    model_answer = '<Answer>\nA2A is an agent-to-agent protocol.\n</Answer>'
+    decide_history: list[list[dict]] = []
+
+    async def fake_decide(question: str, called_tools: list[dict] | None = None) -> object:
+        del question
+        decide_history.append(list(called_tools or []))
+        if not called_tools:
+            return iter([tool_call])
+        return iter([model_answer])
+
+    async def fake_call_tool(tools: list[dict]) -> list[SimpleNamespace]:
+        del tools
+        return [
+            SimpleNamespace(
+                isError=False,
+                content=[SimpleNamespace(text='docs')],
+            )
+        ]
+
+    async def collect_events() -> list[dict]:
+        agent = Agent(mcp_url='https://example.test/mcp')
+        agent.decide = fake_decide
+        agent.call_tool = fake_call_tool
+        return [event async for event in agent.stream('What is A2A?')]
+
+    events = asyncio.run(collect_events())
+    complete_events = [event for event in events if event['is_task_complete']]
+    contents = [event['content'] for event in events]
+
+    assert len(complete_events) == 1
+    assert complete_events[0]['content'] == model_answer
+    assert complete_events[0]['content'] != 'Task completed'
+    assert not any(content.startswith('Step ') for content in contents)
+    assert 'Previous tools have been called.' not in contents
+    assert len(decide_history) == DECIDE_TURNS
+    assert decide_history[1][0]['name'] == 'fetch_A2A_documentation'


### PR DESCRIPTION
Fixes #438.

`Agent.stream` stored each MCP call as `{'tool': name, ...}`, but `called_tools_history.jinja` reads `tool.name`. The next decide prompt showed a blank tool name, so the agent could not see what it already called.

When no further tools were needed, the complete event also replaced the last model response with `Task completed`. Clients that read the final artifact got the placeholder instead of the `<Answer>` body.

This change stores the history record under `name` (and includes `isError` in the template), keeps the last model response as the complete content, and stops emitting `Step N` / raw history strings as artifact text. Tests render the real Jinja template and check the complete event.

Tested with:

```text
uv run --with pytest --directory samples/python/agents/a2a-mcp-without-framework pytest tests/test_tool_history.py -q
```
